### PR TITLE
Provide an implementation of the systemd.tmpfiles.rules NixOS option

### DIFF
--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -6,6 +6,7 @@
   imports = [
     ./etc.nix
     ./systemd.nix
+    ./tmpfiles.nix
     ./upstream/nixpkgs
   ];
 

--- a/nix/modules/tmpfiles.nix
+++ b/nix/modules/tmpfiles.nix
@@ -1,0 +1,27 @@
+{ config, lib, ... }:
+let
+  inherit (lib) types;
+in
+{
+  options = {
+    systemd.tmpfiles.rules = lib.mkOption {
+      type = types.listOf types.str;
+      default = [];
+      example = [ "d /tmp 1777 root root 10d" ];
+      description = lib.mdDoc ''
+        Rules for creation, deletion and cleaning of volatile and temporary files
+        automatically. See
+        {manpage}`tmpfiles.d(5)`
+        for the exact format.
+      '';
+    };
+  };
+
+  config = {
+    environment.etc."tmpfiles.d/00-system-manager.conf".text = ''
+      # This file is created automatically and should not be modified.
+      # Please change the option ‘systemd.tmpfiles.rules’ instead.
+      ${lib.concatStringsSep "\n" config.systemd.tmpfiles.rules}
+    '';
+  };
+}

--- a/src/activate.rs
+++ b/src/activate.rs
@@ -105,6 +105,8 @@ pub fn activate(store_path: &StorePath, ephemeral: bool) -> Result<()> {
     }
     .write_to_file(state_file)?;
 
+    // TODO: execute systemd-tmpfiles
+
     Ok(())
 }
 


### PR DESCRIPTION
Since `systemd` is pretty standardized this PR should be distro agnostic 👍.

I tested activation with this PR followed by running `systemd-tmpfiles --create` and everything worked as expected. Given the number of NixOS modules which use `systemd.tmpfiles.rules` this should be fairly helpful.

Sorry I didn't implement the `rust` part but I'm not a `rust` developer 🤷‍♂️ Hopefully this is at least _some_ value to you.

--- EDIT by @R-VdP ---

I'm adding a checklist of items to do before merging this:
- [ ] Finalise the implementation, create new files at activation time.
- [ ] Write a VM test for this functionality
- [ ] Deal with tmpfiles config in packages (once we have a notion of system-manager packages), like it's done in NixOS. Packages can provide files in `/lib/tmpfiles.d` to be included in the tmpfiles config.
