### PR TITLE
Introduce an intermediate target for systemd services.

### DIFF
--- a/nix/modules/upstream/nixpkgs/nginx.nix
+++ b/nix/modules/upstream/nixpkgs/nginx.nix
@@ -1,5 +1,13 @@
+{ lib, ... }:
 {
-  systemd.services.nginx.serviceConfig.DynamicUser = true;
+  systemd.services.nginx = {
+    serviceConfig.DynamicUser = true;
+
+    # TODO: can we handle this better?
+    wantedBy = lib.mkForce [
+      "system-manager.target"
+    ];
+  };
 
   # Disable this for now
   services.logrotate.settings.nginx = { };


### PR DESCRIPTION
Restarting the active targets seems to cause issues on Ubuntu, restarting certain targets causes the display manager to exit.

Fixes #1.