### PR TITLE
Fix missing function parameter in README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A basic Nix flake using System Manager would look something like this:
     };
   };
 
-  outputs = { self, nixpkgs, system-manager }: {
+  outputs = { self, flake-utils, nixpkgs, system-manager }: {
     systemConfigs.default = self.lib.makeSystemConfig {
       system = flake-utils.lib.system.x86_64-linux;
       modules = [


### PR DESCRIPTION
Missing parameter of function `output` caused error.
```
error: undefined variable 'flake-utils'

       at /nix/store/jhpa26hnm5h58yw88qm6flvhchnzbl8n-source/flake.nix:15:16:

           14|     systemConfigs.default = self.lib.makeSystemConfig {
           15|       system = flake-utils.lib.system.x86_64-linux;
             |                ^
           16|       modules = [
```