### PR TITLE
flake.nix: add workaround for ipetkov/crane#385

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -85,6 +85,8 @@
           nativeBuildInputs = [
             pkg-config
           ];
+          # https://github.com/ipetkov/crane/issues/385
+          doNotLinkInheritedArtifacts = true;
         };
 
         # Build only the cargo dependencies


### PR DESCRIPTION
system-manager currently fails to build on nixpkgs master with the following error:
```console
error: builder for '/nix/store/whz63ya63ha11bzqrwjcqfkivxrg52q9-system-manager-0.1.0.drv' failed with exit code 101;
       last 10 log lines:
       > will append /build/source/.cargo-home/config.toml with contents of /nix/store/1mqzrm4lka0w8r2sxqcnlyq4pdbr4m9z-vendor-cargo-deps/config.toml
       > default configurePhase, nothing to do
       > building
       > ++ command cargo --version
       > cargo 1.72.0 (103a7ff2e 2023-08-15)
       > ++ command cargo build --release --message-format json-render-diagnostics --locked
       >    Compiling libdbus-sys v0.2.5
       > error: output file /build/source/target/release/deps/liblibdbus_sys-6348d0f22c139ac6.rmeta is not writeable -- check its permissions
       >
       > error: could not compile `libdbus-sys` (lib) due to previous error
       For full logs, run 'nix log /nix/store/whz63ya63ha11bzqrwjcqfkivxrg52q9-system-manager-0.1.0.drv'.
error: 1 dependencies of derivation '/nix/store/qbz0zwl83amd3c4kckq8qh65aflg0av3-system-manager.drv' failed to build
```
The issue is tracked in https://github.com/ipetkov/crane/issues/385. This PR includes a crane option `doNotLinkInheritedArtifacts` to fix the build. This workaround is borrowed from https://github.com/linyinfeng/oranc/commit/c63221745166e2af69b7bf5e937236dd3197bb29.