### PR TITLE
fixup: use types.attrs instead of the nonexistent types.freeform

### DIFF
--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -75,14 +75,14 @@
       services.logrotate = lib.mkOption {
         internal = true;
         default = { };
-        type = types.freeform;
+        type = types.attrs;
       };
 
       # No-op option for now.
       users = lib.mkOption {
         internal = true;
         default = { };
-        type = types.freeform;
+        type = types.attrs;
       };
 
       networking = {


### PR DESCRIPTION
fixup for a little typo as `types.freeform` doesn't exist