### PR TITLE
Fix pre-popopulate script name

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,7 @@ fn do_prepopulate(
     if let Some(target_host) = target_host {
         invoke_remote_script(
             &store_path.store_path,
-            "pre-populate",
+            "prepopulate",
             target_host,
             use_remote_sudo,
         )?;


### PR DESCRIPTION
Running

    nix run 'github:numtide/system-manager' -- --target-host XXX pre-populate --flake .

fails with the following error:

    bash: line 1: /nix/store/mij0x8wba9baq05863shk7hbdw39azvr-system-manager/bin/pre-populate: No such file or directory

The reason is that the script has no dash in its name (see [here](https://github.com/numtide/system-manager/blob/fe08568d4a68676bf961f3187964f898054ffa37/nix/modules/default.nix#L175)). This commit fixes the problem.