### PR TITLE
nixpkgs: support buildPlatform, hostPlatform, and overlays

### DIFF
--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -20,11 +20,21 @@
     in
     {
       nixpkgs = {
-        # TODO: switch to lib.systems.parsedPlatform
-        hostPlatform = lib.mkOption {
+        buildPlatform = lib.mkOption {
           type = types.str;
           example = "x86_64-linux";
+          default = config.nixpkgs.hostPlatform;
+        };
+
+        hostPlatform = lib.mkOption {
+          type = with types; either str attrs;
+          example = "x86_64-linux";
           default = throw "the option nixpkgs.hostPlatform needs to be set.";
+        };
+
+        overlays = lib.mkOption {
+          type = with types; listOf anything;
+          default = [];
         };
 
         config = lib.mkOption {


### PR DESCRIPTION
This PR provides a couple mechanisms to set an overlay in nixpkgs, and compile system-manager for another architecture:

- `overlays` argument to makeSystemConfig
- `nixpkgs.hostPlatform`, `nixpkgs.buildPlatform`, and `nixpkgs.overlays`

The reason to have two ways of configuring overlays is to avoid possible infinite recursion, if the module references an overlay that also references the system config.

This lets you use system-manager for (e.g.) ARM:

```nix
{
  nixpkgs = {
    buildPlatform = "x86_64-linux";
    hostPlatform = lib.recursiveUpdate lib.systems.examples.aarch64-multiplatform {
      linuxArch = "arm64";
      linux-kernel = {
        name = "aarch64-multiplatform";
        baseConfig = "defconfig";
        DTB = true;
        autoModules = true;
        preferBuiltin = true;
        target = "Image.gz";
      };
      gcc.arch = "armv8-a";
    };
  };
}
```

Closes #165.