### PR TITLE
chore: Fix clippy warnings

### DIFF
--- a/src/activate/services.rs
+++ b/src/activate/services.rs
@@ -114,15 +114,15 @@ fn get_services_to_reload(services: Services, old_services: Services) -> Service
 
 fn systemd_system_dir(ephemeral: bool) -> PathBuf {
     if ephemeral {
-        return Path::new(path::MAIN_SEPARATOR_STR)
+        Path::new(path::MAIN_SEPARATOR_STR)
             .join("run")
             .join("systemd")
-            .join("system");
+            .join("system")
     } else {
-        return Path::new(path::MAIN_SEPARATOR_STR)
+        Path::new(path::MAIN_SEPARATOR_STR)
             .join("etc")
             .join("systemd")
-            .join("system");
+            .join("system")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@ impl AsRef<StorePath> for StorePath {
     }
 }
 
-impl<'a> From<StorePath> for Cow<'a, StorePath> {
+impl From<StorePath> for Cow<'_, StorePath> {
     fn from(value: StorePath) -> Self {
         Cow::Owned(value)
     }

--- a/src/systemd/manager.rs
+++ b/src/systemd/manager.rs
@@ -668,8 +668,8 @@ impl dbus::message::SignalArgs for OrgFreedesktopSystemd1ManagerReloading {
     const INTERFACE: &'static str = "org.freedesktop.systemd1.Manager";
 }
 
-impl<'a, T: blocking::BlockingSender, C: ::std::ops::Deref<Target = T>>
-    OrgFreedesktopSystemd1Manager for blocking::Proxy<'a, C>
+impl<T: blocking::BlockingSender, C: ::std::ops::Deref<Target = T>> OrgFreedesktopSystemd1Manager
+    for blocking::Proxy<'_, C>
 {
     fn get_unit(&self, name: &str) -> Result<dbus::Path<'static>, dbus::Error> {
         self.method_call("org.freedesktop.systemd1.Manager", "GetUnit", (name,))

--- a/src/systemd/unit.rs
+++ b/src/systemd/unit.rs
@@ -146,8 +146,8 @@ pub trait OrgFreedesktopSystemd1Unit {
     fn activation_details(&self) -> Result<Vec<(String, String)>, dbus::Error>;
 }
 
-impl<'a, T: blocking::BlockingSender, C: ::std::ops::Deref<Target = T>> OrgFreedesktopSystemd1Unit
-    for blocking::Proxy<'a, C>
+impl<T: blocking::BlockingSender, C: ::std::ops::Deref<Target = T>> OrgFreedesktopSystemd1Unit
+    for blocking::Proxy<'_, C>
 {
     fn start(&self, mode: &str) -> Result<dbus::Path<'static>, dbus::Error> {
         self.method_call("org.freedesktop.systemd1.Unit", "Start", (mode,))


### PR DESCRIPTION
Handles a few remaining warnings regarding unneeded return statements and redundant lifetime declarations.