### PR TITLE
feat: Add init subcommand

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Manage system config using nix on any distro";
+  description = "Manage system configurations using Nix on any Linux distribution.";
 
   nixConfig = {
     extra-substituters = [ "https://numtide.cachix.org" ];
@@ -90,5 +90,21 @@
               });
           }
       );
+
+      nixosModules = rec {
+        system-manager = ./nix/modules;
+        default = system-manager;
+      };
+
+      templates = {
+        standalone = {
+          path = ./templates/standalone;
+          description = "System Manager standalone setup";
+        };
+        nixos = {
+          path = ./templates/nixos;
+          description = "System Manager as a NixOS module";
+        };
+      };
     };
 }

--- a/package.nix
+++ b/package.nix
@@ -23,6 +23,7 @@ let
         ./Cargo.lock
         ./src
         ./test/rust
+        ./templates
       ];
     };
 

--- a/shell.nix
+++ b/shell.nix
@@ -40,5 +40,6 @@ pkgs.mkShellNoCC {
     clippy
     mdbook
     mdformat
+    rust-analyzer
   ];
 }

--- a/templates/nixos/flake.nix
+++ b/templates/nixos/flake.nix
@@ -1,0 +1,33 @@
+{
+  description = "NixOS System Manager configuration";
+
+  inputs = {
+    # Specify the source of System Manager and Nixpkgs.
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    system-manager = {
+      url = "github:numtide/system-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      system-manager,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      nixosConfigurations.default = nixpkgs.lib.nixosSystem {
+        inherit system;
+        modules = [
+          ./configuration.nix
+          ./system.nix
+          system-manager.nixosModules.system-manager
+        ];
+      };
+    };
+}

--- a/templates/standalone/flake.nix
+++ b/templates/standalone/flake.nix
@@ -1,0 +1,32 @@
+{
+  description = "Standalone System Manager configuration";
+
+  inputs = {
+    # Specify the source of System Manager and Nixpkgs.
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    system-manager = {
+      url = "github:numtide/system-manager";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      system-manager,
+      ...
+    }:
+    let
+      system = "x86_64-linux";
+    in
+    {
+      systemConfigs.default = system-manager.lib.makeSystemConfig {
+        # Specify your system configuration modules here, for example,
+        # the path to your system.nix.
+        modules = [ ./system.nix ];
+
+        # Optionally specify extraSpecialArgs and overlays
+      };
+    };
+}

--- a/templates/system.nix
+++ b/templates/system.nix
@@ -1,0 +1,55 @@
+{ lib, pkgs, ... }:
+{
+  config = {
+    nixpkgs.hostPlatform = "x86_64-linux";
+
+    # Enable and configure services
+    services = {
+      # nginx.enable = true;
+    };
+
+    environment = {
+      # Packages that should be installed on a system
+      systemPackages = [
+        # pkgs.hello
+      ];
+
+      # Add directories and files to `/etc` and set their permissions
+      etc = {
+        # with_ownership = {
+        #   text = ''
+        #     This is just a test!
+        #   '';
+        #   mode = "0755";
+        #   uid = 5;
+        #   gid = 6;
+        # };
+        #
+        # with_ownership2 = {
+        #   text = ''
+        #     This is just a test!
+        #   '';
+        #   mode = "0755";
+        #   user = "nobody";
+        #   group = "users";
+        # };
+      };
+    };
+
+    # Enable and configure systemd services
+    systemd.services = { };
+
+    # Configure systemd tmpfile settings
+    systemd.tmpfiles = {
+      # rules = [
+      #   "D /var/tmp/system-manager 0755 root root -"
+      # ];
+      #
+      # settings.sample = {
+      #   "/var/tmp/sample".d = {
+      #     mode = "0755";
+      #   };
+      # };
+    };
+  };
+}


### PR DESCRIPTION
Closes #205 

Adds a subcommand for initializing a new configuration at a given path, similarly to home-manager initializing `home.nix` at `~/.config/home-manager`. The template configuration files will be available under the `templates` attribute on the flake, and included in the system-manager binary to avoid unnecessary network calls.