### PR TITLE
fix: add system-manager-unwrapped back to packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,6 +34,10 @@
     {
       lib = import ./nix/lib.nix { inherit nixpkgs; };
 
+      # The unwrapped version takes nix from the PATH, it will fail if nix
+      # cannot be found.
+      # The wrapped version has a reference to the nix store path, so nix is
+      # part of its runtime closure.
       packages = eachSystem (
         { pkgs, system }:
         import ./packages.nix { inherit pkgs; }


### PR DESCRIPTION
Some users have reported that they rely on the unwrapped version of system-manager and that updating to latest throws an error that the attribute for it no longer exists. After some digging it would seem that #125 removes the unwrapped bin from #24, so this commit just adds it back for users that need it.