### PR TITLE
Support attribute sets with string keys

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -21,6 +21,7 @@ let
           ./Cargo.toml
           ./Cargo.lock
           ./src
+          ./test/rust
         ];
       };
 
@@ -32,10 +33,16 @@ let
 
       nativeCheckInputs = [
         clippy
+        nix
       ];
 
       preCheck = ''
         ${lib.getExe pkgs.cargo} clippy
+
+        # Stop the Nix command from trying to create /nix/var/nix/profiles.
+        #
+        # https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix3-profile#profiles
+        export NIX_STATE_DIR=$TMPDIR
       '';
     }
   ) { };

--- a/src/register.rs
+++ b/src/register.rs
@@ -173,7 +173,7 @@ fn try_nix_eval(flake: &str, attr: &str, nix_options: &NixOptions) -> Result<boo
         .arg(format!("{flake}#{FLAKE_ATTR}"))
         .arg("--json")
         .arg("--apply")
-        .arg(format!("a: a ? \"{attr}\""));
+        .arg(format!("_: _ ? {attr}"));
 
     log::debug!("Running nix command: {cmd:?}");
 
@@ -196,4 +196,20 @@ fn nix_cmd(nix_options: &NixOptions) -> process::Command {
         cmd.arg("--option").arg(&option.0).arg(&option.1);
     });
     cmd
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_try_nix_eval() {
+        let flake = "./test/rust/register";
+        let nix_options = &NixOptions::new(vec![]);
+
+        assert!(try_nix_eval(flake, "identifier-key", nix_options).unwrap());
+        assert!(try_nix_eval(flake, "\"string.literal/key\"", nix_options).unwrap());
+        assert!(!try_nix_eval(flake, "_identifier-key", nix_options).unwrap());
+        assert!(!try_nix_eval(flake, "\"_string.literal/key\"", nix_options).unwrap());
+    }
 }

--- a/test/rust/register/flake.nix
+++ b/test/rust/register/flake.nix
@@ -1,0 +1,9 @@
+{
+  inputs = { };
+  outputs = inputs: {
+    systemConfigs = {
+      identifier-key = "value";
+      "string.literal/key" = "value";
+    };
+  };
+}


### PR DESCRIPTION
Fixes https://github.com/numtide/system-manager/issues/219.

`flake.nix`

```nix
{
  inputs = { };
  outputs = {
    systemConfigs = {
      hello-world = "hi";
      "hello.world" = "hi";
      "goodbye.world" = {
        good = "bye";
      };
    };
  };
}
```

```shell
$ nix eval .#systemConfigs --json --apply '_: _ ? hello-world'
true

$ nix eval .#systemConfigs --json --apply '_: _ ? "hello.world"'
true

$ nix eval .#systemConfigs --json --apply '_: _ ? hello.world' 
false

$ nix eval .#systemConfigs --json --apply '_: _ ? nonexistent'
false

$ nix eval .#systemConfigs --json --apply '_: _ ? "goodbye.world".good'
true
```