### PR TITLE
(Fix) Fix cross compilation

### DIFF
--- a/packages.nix
+++ b/packages.nix
@@ -52,7 +52,7 @@ in
   system-manager =
     pkgs.runCommand "system-manager"
       {
-        nativeBuildInputs = [ pkgs.makeBinaryWrapper ];
+        nativeBuildInputs = [ pkgs.pkgsBuildHost.makeBinaryWrapper ];
       }
       ''
         makeWrapper \


### PR DESCRIPTION
Fix cross compilation issue by explicitly using makeBinaryWrapper from pkgsBuildHost