### PR TITLE
environment.shellAliases: init

### DIFF
--- a/examples/example.nix
+++ b/examples/example.nix
@@ -11,6 +11,10 @@
         pkgs.fd
       ];
 
+      shellAliases = {
+        nr = "nixpkgs-review pr";
+      };
+
       etc = {
         foo = {
           text = ''

--- a/test/nix/modules/default.nix
+++ b/test/nix/modules/default.nix
@@ -321,6 +321,8 @@ forEachUbuntuImage "example" {
         vm.succeed("bash --login -c 'realpath $(which rg) | grep -F ${hostPkgs.ripgrep}/bin/rg'")
         vm.succeed("bash --login -c 'realpath $(which fd) | grep -F ${hostPkgs.fd}/bin/fd'")
 
+        vm.succeed("bash --login -c 'type nr'")
+
         ${system-manager.lib.activateProfileSnippet {
           node = "vm";
           profile = newConfig;


### PR DESCRIPTION
Mirrors the NixOS/nix-darwin module that allows one to define shell aliases declaratively.