### PR TITLE
Configure nix settings

### DIFF
--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -7,6 +7,7 @@
   imports =
     [
       ./nginx.nix
+      ./nix.nix
     ]
     ++
     # List of imported NixOS modules
@@ -15,6 +16,8 @@
       "/misc/meta.nix"
       "/security/acme/"
       "/services/web-servers/nginx/"
+      # nix settings
+      "/config/nix.nix"
     ];
 
   options =

--- a/nix/modules/upstream/nixpkgs/nix.nix
+++ b/nix/modules/upstream/nixpkgs/nix.nix
@@ -1,0 +1,25 @@
+{ lib, pkgs, ... }:
+{
+  options = {
+    # options coming from modules/services/system/nix-daemon.nix that we cannot import just yet because it
+    # depends on users. These are the minimum options we need to be able to configure Nix using system-manager.
+    nix = {
+      enable = lib.mkOption {
+        type = lib.types.bool;
+        default = true;
+        description = ''
+          Whether to enable Nix.
+          Disabling Nix makes the system hard to modify and the Nix programs and configuration will not be made available by NixOS itself.
+        '';
+      };
+      package = lib.mkOption {
+        type = lib.types.package;
+        default = pkgs.nix;
+        defaultText = lib.literalExpression "pkgs.nix";
+        description = ''
+          This option specifies the Nix package instance to use throughout the system.
+        '';
+      };
+    };
+  };
+}

--- a/test/nix/modules/default.nix
+++ b/test/nix/modules/default.nix
@@ -134,6 +134,16 @@ let
                 '';
               };
             };
+
+            nix = {
+              settings = {
+                experimental-features = [
+                  "nix-command"
+                  "flakes"
+                ];
+                trusted-users = [ "zimbatm" ];
+              };
+            };
           };
         }
       )
@@ -149,7 +159,7 @@ forEachUbuntuImage "example" {
   ];
   extraPathsToRegister = [ newConfig ];
   testScriptFunction =
-    { toplevel, ... }:
+    { toplevel, hostPkgs, ... }:
     #python
     ''
       # Start all machines in parallel
@@ -222,6 +232,9 @@ forEachUbuntuImage "example" {
       vm.fail("test -f /etc/a/nested/example/foo3")
       vm.fail("test -f /etc/baz/bar/foo2")
       vm.succeed("test -f /etc/foo_new")
+
+      nix_trusted_users = vm.succeed("${hostPkgs.nix}/bin/nix config show trusted-users").strip()
+      assert "zimbatm" in nix_trusted_users, f"Expected 'zimbatm' to be in trusted-users, got {nix_trusted_users}"
 
       ${system-manager.lib.deactivateProfileSnippet {
         node = "vm";


### PR DESCRIPTION
Only manage /etc/nix/nix.conf options based on nixpkgs options. We cannot control nix-gc / nix-daemon services yet as they rely on users.

refs #228 