### PR TITLE
feat: add our cachix substituter to nix config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,6 +1,11 @@
 {
   description = "Manage system config using nix on any distro";
 
+  nixConfig = {
+    extra-substituters = [ "https://numtide.cachix.org" ];
+    extra-trusted-public-keys = [ "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE=" ];
+  };
+
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
   outputs =


### PR DESCRIPTION
Improve the user experience by enabling download of prebuilt binaries instead of forcing them to build from source.