### PR TITLE
Tweaks to package.nix (particularly pertinent in cross-compilation context)

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -52,17 +52,15 @@ in
 runCommand "system-manager"
   {
     nativeBuildInputs = [ makeBinaryWrapper ];
-    passthru = {
-      # The unwrapped version takes nix from the PATH, it will fail if nix
-      # cannot be found.
-      # The wrapped version has a reference to the nix store path, so nix is
-      # part of its runtime closure.
-      unwrapped = system-manager-unwrapped;
-    };
+    # The unwrapped version takes nix from the PATH, it will fail if nix
+    # cannot be found.
+    # The wrapped version has a reference to the nix store path, so nix is
+    # part of its runtime closure.
+    unwrapped = system-manager-unwrapped;
   }
   ''
     makeWrapper \
-      ${system-manager-unwrapped}/bin/system-manager \
+      $unwrapped/bin/system-manager \
       $out/bin/system-manager \
       --prefix PATH : ${lib.makeBinPath [ nix ]}
   ''


### PR DESCRIPTION
The first commit solves a very real issue of having to build the whole Rust toolchain for the target system (starting with binutils and llvm) for absolutely no reason (see commit description for details). This issue gives me some amount of grief at the moment, so if we can get it merged that would be absolutely fabulous.

The second commit just fixes a weirdness I've ran into while trying to work around the first one (TL;DR you can't `overrideAttrs` because `buildRustPackage` output is hard-coded into `runCommand` script, arguably for no good reason). This one is optional, we can split it off to a separate PR or drop it altogether if it seems controversial.