### PR TITLE
flake: migrate from cachix to cache.numtide.com

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,8 +2,8 @@
   description = "Manage system configurations using Nix on any Linux distribution.";
 
   nixConfig = {
-    extra-substituters = [ "https://numtide.cachix.org" ];
-    extra-trusted-public-keys = [ "numtide.cachix.org-1:2ps1kLBUWjxIneOy1Ik6cQjb41X0iXVXeHigGmycPPE=" ];
+    extra-substituters = [ "https://cache.numtide.com" ];
+    extra-trusted-public-keys = [ "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=" ];
   };
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";


### PR DESCRIPTION
Numtide is migrating from Cachix to a self-hosted binary cache at https://cache.numtide.com.

This PR updates:
- `extra-substituters`: `https://numtide.cachix.org` → `https://cache.numtide.com`
- `extra-trusted-public-keys`: Updated to the new cache's public key

Users will continue to receive pre-built binaries seamlessly from the new infrastructure.