### PR TITLE
Update nixpkgs and nix-vm-test

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1765472234,
-        "narHash": "sha256-9VvC20PJPsleGMewwcWYKGzDIyjckEz8uWmT0vCDYK0=",
+        "lastModified": 1766902085,
+        "narHash": "sha256-coBu0ONtFzlwwVBzmjacUQwj3G+lybcZ1oeNSQkgC0M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2fbfb1d73d239d2402a8fe03963e37aab15abe8b",
+        "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -26,8 +26,8 @@
         );
       nix-vm-test-lib =
         let
-          rev = "e34870b8dd2c2d203c05b4f931b8c33eaaf43b81";
-          sha256 = "sha256:1qp1fq96kv9i1nj20m25057pfcs1b1c9bj4502xy7gnw8caqr30d";
+          rev = "991369a72fe577c2bcdad0b26bf8c63a6f94f84b";
+          sha256 = "sha256:1ygn0acvzzrg0jbnbpwfl4n4k2ka6ay0x34sj61g11c1pvckl3m9";
         in
         "${
           builtins.fetchTarball {


### PR DESCRIPTION
The last nixpkgs update also requires nix-vm-test to be updated:

- https://github.com/numtide/nix-vm-test/pull/147 to fix the test driver
- https://github.com/numtide/nix-vm-test/pull/150 to fix registration of store paths in the Nix database, which was broken in tests using extraPathsToRegister.

