### PR TITLE
feat: add darwin compatibility

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -13,6 +13,7 @@
     let
       systems = [
         "aarch64-linux"
+        "aarch64-darwin"
         "x86_64-linux"
       ];
       eachSystem =

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -39,13 +39,13 @@
 
         config = lib.mkOption {
           type = types.attrs;
-          description = ''Configuration used to instantiate nixpkgs.'';
+          description = "Configuration used to instantiate nixpkgs.";
           default = { };
         };
 
         pkgs = lib.mkOption {
           type = lib.types.pkgs;
-          description = ''The pkgs module argument.'';
+          description = "The pkgs module argument.";
           default = pkgs;
           readOnly = true;
           internal = true;
@@ -312,7 +312,7 @@
       services = lib.mapAttrs' (
         unitName: unit:
         lib.nameValuePair unitName {
-          storePath = ''${unit.unit}/${unitName}'';
+          storePath = "${unit.unit}/${unitName}";
         }
       ) (lib.filterAttrs (_: unit: unit.enable) config.systemd.units);
     };

--- a/shell.nix
+++ b/shell.nix
@@ -7,26 +7,16 @@ in
 pkgs.mkShellNoCC {
   shellHook = ''
     ${pkgs.pre-commit}/bin/pre-commit install --install-hooks --overwrite
-    export PKG_CONFIG_PATH="${
-      pkgs.lib.makeSearchPath "lib/pkgconfig" [
-        pkgs.dbus.dev
-        pkgs.systemdMinimal.dev
-      ]
-    }"
+    export PKG_CONFIG_PATH="${pkgs.lib.makeSearchPath "lib/pkgconfig" [ pkgs.dbus.dev ]}"
     export LIBCLANG_PATH="${llvm.libclang}/lib"
     # for rust-analyzer
     export RUST_SRC_PATH="${pkgs.rustPlatform.rustLibSrc}"
     export RUST_BACKTRACE=1
-    export RUSTFLAGS="${
-      pkgs.lib.concatStringsSep " " [
-        "-L${pkgs.lib.getLib pkgs.systemdMinimal}/lib"
-        "-lsystemd"
-      ]
-    }"
   '';
-  buildInputs = with pkgs; [
-    dbus
-  ];
+  buildInputs = [
+    pkgs.dbus
+  ]
+  ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isDarwin [ pkgs.libiconv ];
   nativeBuildInputs = with pkgs; [
     llvm.clang
     pkg-config


### PR DESCRIPTION
The goal is to be able to run/build system manager from darwin (to configure a remote Ubuntu machine)

We removed the unnecessary systemdMinimal dependency (dbus crate only needs libdbus).