### PR TITLE
feat(test): add docker test infrastructure

### DIFF
--- a/.treefmt.toml
+++ b/.treefmt.toml
@@ -7,3 +7,7 @@ includes = ["*.nix"]
 [formatter.rustfmt]
 command = "rustfmt"
 includes = ["*.rs"]
+
+[formatter.uv]
+command = "black"
+includes = ["*.py"]

--- a/flake.nix
+++ b/flake.nix
@@ -45,6 +45,13 @@
         {
           default = pkgs.callPackage ./package.nix { };
         }
+        // nixpkgs.lib.optionalAttrs (system == "x86_64-linux" || system == "aarch64-linux") {
+          docker-test = import ./test/docker {
+            inherit (nixpkgs) lib;
+            inherit pkgs;
+            system-manager = self;
+          };
+        }
       );
 
       # Documentation outputs

--- a/shell.nix
+++ b/shell.nix
@@ -32,6 +32,7 @@ pkgs.mkShellNoCC {
     mdformat
     rust-analyzer
     gh
+    black
     # Testing tools
     parallel
   ];

--- a/test/docker/conftest.py
+++ b/test/docker/conftest.py
@@ -1,0 +1,114 @@
+import pytest
+import shutil
+import subprocess
+import testinfra
+import time
+from rich.console import Console
+
+console = Console()
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--image-name",
+        action="store",
+        help="Docker image and tag to use for testing",
+    )
+    parser.addoption(
+        "--image-path",
+        action="store",
+        help="Compressed Docker image to load for testing",
+    )
+    parser.addoption(
+        "--force-docker",
+        action="store_true",
+        help="Force using Docker instead of Podman for testing",
+    )
+
+
+@pytest.fixture(scope="session")
+def host(request):
+    force_docker = request.config.getoption("--force-docker")
+    image_name = request.config.getoption("--image-name")
+    image_path = request.config.getoption("--image-path")
+    if not force_docker and shutil.which("podman"):
+        console.log("Using Podman for testing")
+        with console.status("Loading image..."):
+            subprocess.check_output(["podman", "load", "-q", "-i", image_path])
+        podman_id = (
+            subprocess.check_output(
+                [
+                    "podman",
+                    "run",
+                    "--cap-add",
+                    "SYS_ADMIN",
+                    "-d",
+                    image_name,
+                ]
+            )
+            .decode()
+            .strip()
+        )
+        yield testinfra.get_host("podman://" + podman_id)
+        with console.status("Cleaning up..."):
+            subprocess.check_call(
+                ["podman", "rm", "-f", podman_id], stdout=subprocess.DEVNULL
+            )
+    else:
+        console.log("Using Docker for testing")
+        with console.status("Loading image..."):
+            subprocess.check_output(["docker", "load", "-q", "-i", image_path])
+        docker_id = (
+            subprocess.check_output(
+                [
+                    "docker",
+                    "run",
+                    "--privileged",
+                    "--cap-add",
+                    "SYS_ADMIN",
+                    "--security-opt",
+                    "seccomp=unconfined",
+                    "--cgroup-parent=docker.slice",
+                    "--cgroupns",
+                    "private",
+                    "-d",
+                    image_name,
+                ]
+            )
+            .decode()
+            .strip()
+        )
+        yield testinfra.get_host("docker://" + docker_id)
+        with console.status("Cleaning up..."):
+            subprocess.check_call(
+                ["docker", "rm", "-f", docker_id], stdout=subprocess.DEVNULL
+            )
+
+
+def wait_for_target(host, target, timeout=60):
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        result = host.run(f"systemctl is-active {target}")
+        if result.rc == 0:
+            return True
+        time.sleep(0.2)
+    return False
+
+
+@pytest.fixture(scope="session", autouse=True)
+def activate_system_manager(host):
+    with console.status("Waiting for systemd to be ready..."):
+        assert wait_for_target(
+            host, "multi-user.target"
+        ), "systemd multi-user.target not reached"
+    result = host.run("activate")
+    console.log(result.stdout)
+    console.log(result.stderr)
+    if result.failed:
+        raise pytest.fail(
+            "System manager activation failed with return code {}".format(result.rc)
+        )
+    with console.status("Waiting for system-manager.target..."):
+        assert wait_for_target(
+            host, "system-manager.target"
+        ), "system-manager.target not reached"

--- a/test/docker/default.nix
+++ b/test/docker/default.nix
@@ -1,0 +1,101 @@
+{
+  lib,
+  pkgs,
+  system-manager,
+}:
+
+let
+  ubuntu-cloudimg =
+    let
+      cloudImg =
+        if pkgs.stdenv.hostPlatform.system == "x86_64-linux" then
+          builtins.fetchurl {
+            url = "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-amd64-root.tar.xz";
+            sha256 = "0y3d55f5qy7bxm3mfmnxzpmwp88d7iiszc57z5b9npc6xgwi28np";
+          }
+        else
+          builtins.fetchurl {
+            url = "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-arm64-root.tar.xz";
+            sha256 = "1l4l0llfffspzgnmwhax0fcnjn8ih8n4azhfaghng2hh1xvr4a17";
+          };
+    in
+    pkgs.runCommand "ubuntu-cloudimg" { nativeBuildInputs = [ pkgs.xz ]; } ''
+      mkdir -p $out
+      tar --exclude='dev/*' \
+          --exclude='etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service' \
+          --exclude='etc/systemd/system/multi-user.target.wants/systemd-resolved.service' \
+          --exclude='usr/lib/systemd/system/tpm-udev.service' \
+          --exclude='usr/lib/systemd/system/systemd-remount-fs.service' \
+          --exclude='usr/lib/systemd/system/systemd-resolved.service' \
+          --exclude='usr/lib/systemd/system/proc-sys-fs-binfmt_misc.automount' \
+          --exclude='usr/lib/systemd/system/sys-kernel-*' \
+          --exclude='var/lib/apt/lists/*' \
+          -xJf ${cloudImg} -C $out
+      rm -f $out/bin $out/lib $out/lib64 $out/sbin
+      mkdir -p $out/run/systemd && echo 'docker' > $out/run/systemd/container
+      mkdir $out/var/lib/apt/lists/partial
+    '';
+
+  docker-image-ubuntu = pkgs.dockerTools.buildImage {
+    name = "ubuntu-cloudimg";
+    tag = "24.04";
+    created = "now";
+    extraCommands = ''
+      ln -s usr/bin
+      ln -s usr/lib
+      ln -s usr/lib64
+      ln -s usr/sbin
+    '';
+    copyToRoot = pkgs.buildEnv {
+      name = "image-root";
+      pathsToLink = [ "/" ];
+      paths = [ ubuntu-cloudimg ];
+    };
+    config.Cmd = [ "/lib/systemd/systemd" ];
+  };
+
+  systemManagerConfig = system-manager.systemConfigs.default;
+
+  dockerImageWithSystemManager = pkgs.dockerTools.buildLayeredImage {
+    name = "ubuntu-cloudimg-with-system-manager";
+    tag = "0.1";
+    created = "now";
+    maxLayers = 30;
+    fromImage = docker-image-ubuntu;
+    compressor = "zstd";
+    config = {
+      Env = [
+        "PATH=${
+          lib.makeBinPath [ systemManagerConfig ]
+        }:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+      ];
+      Cmd = [ "/lib/systemd/systemd" ];
+    };
+  };
+
+in
+pkgs.writeShellApplication {
+  name = "system-manager-docker-test";
+  passthru = {
+    inherit systemManagerConfig dockerImageWithSystemManager docker-image-ubuntu;
+  };
+  runtimeInputs = with pkgs; [
+    (python3.withPackages (
+      ps: with ps; [
+        requests
+        pytest
+        pytest-testinfra
+        rich
+      ]
+    ))
+  ];
+  text = ''
+    export DOCKER_IMAGE=${dockerImageWithSystemManager.imageName}:${dockerImageWithSystemManager.imageTag}
+    TEST_DIR=${./.}
+    pytest -p no:cacheprovider -s -v "$@" "$TEST_DIR" --image-name="$DOCKER_IMAGE" --image-path=${dockerImageWithSystemManager}
+  '';
+  meta = with pkgs.lib; {
+    description = "Docker-based tests for system-manager";
+    platforms = platforms.linux;
+  };
+}

--- a/test/docker/test_system_manager.py
+++ b/test/docker/test_system_manager.py
@@ -1,0 +1,63 @@
+"""Docker-based tests for system-manager.
+
+These tests validate that system-manager correctly activates and manages
+systemd services and configuration files in a containerized environment.
+We are using testinfra to interact with the container and verify the expected
+state of services and files after system-manager activation.
+
+We validate the configuration examples provided in `examples/example.nix`.
+"""
+
+
+def test_nginx_service(host):
+    """Verify nginx service is valid and running after activation."""
+    assert host.service("nginx.service").is_valid
+    assert host.service("nginx.service").is_running
+
+
+def test_system_manager_target(host):
+    """Verify system-manager.target is active."""
+    result = host.run("systemctl is-active system-manager.target")
+    assert result.rc == 0
+
+
+def test_package_installed(host):
+    """Verify that the 'fd' package is installed."""
+    assert host.run("bash -l -c 'fd --help'").rc == 0
+
+
+def test_managed_services(host):
+    """Verify managed services (service-0 through service-9) are active."""
+    for i in range(10):
+        service = host.service(f"service-{i}.service")
+        assert service.is_valid, f"service-{i} should be valid"
+
+
+def test_etc_foo_conf(host):
+    """Verify /etc/foo.conf exists with expected content."""
+    f = host.file("/etc/foo.conf")
+    assert f.exists
+    assert f.contains("launch_the_rockets = true")
+
+
+def test_etc_nested_files(host):
+    """Verify nested etc files are created correctly."""
+    assert host.file("/etc/baz/bar/foo2").exists
+    assert host.file("/etc/a/nested/example/foo3").exists
+    assert host.file("/etc/a/nested/example2/foo3").exists
+
+
+def test_tmpfiles_directories(host):
+    """Verify systemd-tmpfiles directories are created."""
+    assert host.file("/var/tmp/system-manager").is_directory
+    sample_dir = host.file("/var/tmp/sample")
+    assert sample_dir.is_directory
+    assert sample_dir.user == "root"
+    assert sample_dir.group == "root"
+    assert sample_dir.mode == 0o755
+
+
+def test_tmpfiles_conf(host):
+    """Verify tmpfiles configuration files are deployed."""
+    assert host.file("/etc/tmpfiles.d/sample.conf").exists
+    assert host.file("/etc/tmpfiles.d/00-system-manager.conf").exists


### PR DESCRIPTION
Implement a faster feedback loop for testing system-manager using containerized Ubuntu 24.04 image with system-manager layered on top.

This test are not running in the sandboxed Nix build environment, but they provide a quick way to validate changes to system-manager without the overhead of building a full VM image and running it in QEMU.

We also use a well known test framework (testinfra) to simplify writing and maintaining tests.

We use Podman if available, otherwise fallback to Docker.

In this first implementation we validate the configuration examples provided in `examples/example.nix`.