### PR TITLE
refactor: isolate VM tests into separate testFlake

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,6 @@ on:
             - main
         tags:
             - "v*"
-
     # Allows you to run this workflow manually from the Actions tab
     workflow_dispatch:
 

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -14,11 +14,14 @@ jobs:
         uses: "cachix/install-nix-action@master"
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: "Update the lockfile"
+      - name: "Update the lockfiles"
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email 'github-actions[bot]@users.noreply.github.com'
+
           nix flake update --commit-lock-file
+          nix flake update --commit-lock-file --flake ./testFlake
+
           cargo update
           git add Cargo.lock
           # Commit exits with an error when there is nothing to do
@@ -27,6 +30,6 @@ jobs:
         uses: "peter-evans/create-pull-request@v8"
         with:
           branch: "auto_update_deps"
-          title: "Bump flake.lock and Cargo.lock"
+          title: "Bump flake.lock, testFlake/flake.lock, and Cargo.lock"
           body: |
             Automatically bumped the lock files.

--- a/buildbot-nix.toml
+++ b/buildbot-nix.toml
@@ -1,0 +1,6 @@
+# Buildbot-nix configuration
+#
+# Evaluate testFlake which includes:
+# - Parent flake checks (package builds for all systems)
+# - VM integration tests (Ubuntu variants on x86_64-linux)
+flake_dir = "./testFlake"

--- a/flake.nix
+++ b/flake.nix
@@ -25,17 +25,6 @@
             pkgs = nixpkgs.legacyPackages.${system};
           }
         );
-      nix-vm-test-lib =
-        let
-          rev = "991369a72fe577c2bcdad0b26bf8c63a6f94f84b";
-          sha256 = "sha256:1ygn0acvzzrg0jbnbpwfl4n4k2ka6ay0x34sj61g11c1pvckl3m9";
-        in
-        "${
-          builtins.fetchTarball {
-            url = "https://github.com/numtide/nix-vm-test/archive/${rev}.tar.gz";
-            inherit sha256;
-          }
-        }/lib.nix";
     in
     {
       lib = (import ./nix/lib.nix { inherit nixpkgs; }) // {
@@ -76,47 +65,11 @@
         }
       );
 
-      checks = (
-        nixpkgs.lib.recursiveUpdate
-          (eachSystem (
-            { system, ... }:
-            {
-              system-manager = self.packages.${system}.default;
-            }
-          ))
-          {
-            x86_64-linux =
-              let
-                system = "x86_64-linux";
-                vmTests = import ./test/nix/modules {
-                  inherit system;
-                  inherit (nixpkgs) lib;
-                  nix-vm-test = import nix-vm-test-lib {
-                    inherit nixpkgs;
-                    inherit system;
-                  };
-                  system-manager = self;
-                };
-                containerTests = import ./test/nix/modules/container.nix {
-                  inherit system;
-                  inherit (nixpkgs) lib;
-                  hostPkgs = nixpkgs.legacyPackages.${system};
-                  system-manager = self;
-                };
-              in
-              vmTests // containerTests;
-            aarch64-linux =
-              let
-                system = "aarch64-linux";
-                containerTests = import ./test/nix/modules/container.nix {
-                  inherit system;
-                  inherit (nixpkgs) lib;
-                  hostPkgs = nixpkgs.legacyPackages.${system};
-                  system-manager = self;
-                };
-              in
-              containerTests;
-          }
+      checks = eachSystem (
+        { system, ... }:
+        {
+          system-manager = self.packages.${system}.default;
+        }
       );
 
       nixosModules = rec {

--- a/testFlake/container-tests.nix
+++ b/testFlake/container-tests.nix
@@ -7,7 +7,7 @@
 }:
 
 let
-  containerTestLib = import ../../../lib/container-test-driver { inherit lib; };
+  containerTestLib = import ../lib/container-test-driver { inherit lib; };
 
   # Helper to create a container test for a system-manager configuration
   makeContainerTestFor =
@@ -48,7 +48,7 @@ in
 {
   container-example = makeContainerTestFor "example" {
     modules = [
-      ../../../examples/example.nix
+      ../examples/example.nix
     ];
     testScriptFunction =
       { toplevel, hostPkgs, ... }:

--- a/testFlake/flake.lock
+++ b/testFlake/flake.lock
@@ -1,0 +1,66 @@
+{
+  "nodes": {
+    "nix-vm-test": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1770066363,
+        "narHash": "sha256-my1FdRPpPJFbpPAtiGqaADBVK2pbTtqgvu30GEH+WDg=",
+        "owner": "numtide",
+        "repo": "nix-vm-test",
+        "rev": "ac8e37f981e5cb2b16957c019ff1a2202c412718",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-vm-test",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1769789167,
+        "narHash": "sha256-kKB3bqYJU5nzYeIROI82Ef9VtTbu4uA3YydSk/Bioa8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "62c8382960464ceb98ea593cb8321a2cf8f9e3e5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nix-vm-test": "nix-vm-test",
+        "nixpkgs": [
+          "system-manager",
+          "nixpkgs"
+        ],
+        "system-manager": "system-manager"
+      }
+    },
+    "system-manager": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
+      "locked": {
+        "path": "..",
+        "type": "path"
+      },
+      "original": {
+        "path": "..",
+        "type": "path"
+      },
+      "parent": []
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/testFlake/flake.nix
+++ b/testFlake/flake.nix
@@ -1,0 +1,60 @@
+{
+  description = "System Manager VM integration tests";
+
+  nixConfig = {
+    extra-substituters = [ "https://cache.numtide.com" ];
+    extra-trusted-public-keys = [ "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g=" ];
+  };
+
+  inputs = {
+    system-manager.url = "path:..";
+    nixpkgs.follows = "system-manager/nixpkgs";
+    nix-vm-test = {
+      url = "github:numtide/nix-vm-test";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs =
+    {
+      self,
+      system-manager,
+      nixpkgs,
+      nix-vm-test,
+    }:
+    let
+      testedSystems = [
+        "aarch64-linux"
+        "x86_64-linux"
+      ];
+
+      # VM tests only run on x86_64-linux for now
+      vmTestSystem = "x86_64-linux";
+      vmTestLib = import "${nix-vm-test}/lib.nix" {
+        inherit nixpkgs;
+        system = vmTestSystem;
+      };
+      vmChecks = import ./vm-tests.nix {
+        system = vmTestSystem;
+        inherit (nixpkgs) lib;
+        nix-vm-test = vmTestLib;
+        inherit system-manager;
+      };
+      containerChecks =
+        system:
+        import ./container-tests.nix {
+          inherit system;
+          inherit (nixpkgs) lib;
+          hostPkgs = nixpkgs.legacyPackages.${system};
+          inherit system-manager;
+        };
+    in
+    {
+      checks = nixpkgs.lib.genAttrs testedSystems (
+        system:
+        system-manager.checks.${system}
+        // nixpkgs.lib.optionalAttrs (system == vmTestSystem) vmChecks
+        // (containerChecks system)
+      );
+    };
+}

--- a/testFlake/vm-tests.nix
+++ b/testFlake/vm-tests.nix
@@ -158,7 +158,7 @@ in
 forEachUbuntuImage "example" {
   modules = [
     (testModule "old")
-    ../../../examples/example.nix
+    ../examples/example.nix
   ];
   extraPathsToRegister = [ newConfig ];
   testScriptFunction =
@@ -269,7 +269,7 @@ forEachUbuntuImage "example" {
   forEachUbuntuImage "prepopulate" {
     modules = [
       (testModule "old")
-      ../../../examples/example.nix
+      ../examples/example.nix
     ];
     extraPathsToRegister = [ newConfig ];
     testScriptFunction =
@@ -327,7 +327,7 @@ forEachUbuntuImage "example" {
   forEachUbuntuImage "system-path" {
     modules = [
       (testModule "old")
-      ../../../examples/example.nix
+      ../examples/example.nix
     ];
     extraPathsToRegister = [ newConfig ];
     testScriptFunction =
@@ -372,7 +372,7 @@ forEachUbuntuImage "example" {
   forEachUbuntuImage "sudo" {
     modules = [
       (testModule "old")
-      ../../../examples/example.nix
+      ../examples/example.nix
     ];
     extraPathsToRegister = [
       system-manager.packages.x86_64-linux.default
@@ -433,7 +433,7 @@ forEachUbuntuImage "example" {
   forEachUbuntuImage "target-host" {
     modules = [
       (testModule "old")
-      ../../../examples/example.nix
+      ../examples/example.nix
     ];
     extraPathsToRegister = [
       system-manager.packages.x86_64-linux.default


### PR DESCRIPTION
Users consuming system-manager as a flake input only need the package, lib, and modules - not the test infrastructure. By moving VM tests to a subflake, the main flake stays minimal with nixpkgs as its only input.

This separation enables CI to run fast package checks independently from slow VM tests, and provides proper flake.lock version pinning for test dependencies like nix-vm-test (replacing the inline fetchTarball).

Future test dependencies (e.g., sops-nix for compatibility testing in #270) can be added to testFlake without touching the main flake.