### PR TITLE
modules: configure flakes by default

### DIFF
--- a/nix/modules/upstream/nixpkgs/nix.nix
+++ b/nix/modules/upstream/nixpkgs/nix.nix
@@ -22,4 +22,11 @@
       };
     };
   };
+
+  config = {
+    nix.settings.experimental-features = lib.mkDefault [
+      "nix-command"
+      "flakes"
+    ];
+  };
 }


### PR DESCRIPTION
Makes follow-up usage of system-manager easier.