### PR TITLE
docs: update Nix installation instructions to recommend nix-installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,12 +227,13 @@ System Manager is currently only supported on NixOS and Ubuntu. However, it can 
 > [!WARNING]
 > This is unsupported and untested. Use at your own risk.
 
+## Supported Nix
+
+Nix should be installed with the [nix-installer](https://github.com/NixOS/nix-installer).
+System manager is tested against Nix 2.32 and above installed via nix-installer.
+
 ## Commercial support
 
 Looking for help or customization?
 
 Get in touch with Numtide to get a quote. We make it easy for companies to work with Open Source projects: <https://numtide.com/contact>
-
-[detsys-installer]: https://github.com/DeterminateSystems/nix-installer
-[nixos]: https://nixos.org
-[official-installer]: https://nixos.org/download.html

--- a/docs/site/how-to/install.md
+++ b/docs/site/how-to/install.md
@@ -11,22 +11,12 @@ To use System Manager, you need:
 !!! Warning
     Rollback functionality is not yet fully implemented. While you can list and switch between generations manually, automatic rollback on failure is not available. Always test configuration changes in a VM or non-production environment first.
 
-# Installing Nix
-
-If you don't have Nix installed yet, you have two options:
-
-## Option 1: Official Nix Installer (Recommended)
+## Installing Nix
 
 Use the official multi-user installer:
 
 ```sh
-sh <(curl -L https://nixos.org/nix/install) --daemon
-```
-
-After installation, open a new terminal or source the profile:
-
-```sh
-. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
+curl -sSfL https://artifacts.nixos.org/nix-installer | sh -s -- install
 ```
 
 Verify the installation:
@@ -35,16 +25,10 @@ Verify the installation:
 nix --version
 ```
 
-## Option 2: Determinate Systems Installer
+### Enabling flakes
 
-The [Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer) is a wrapper around the official installer with SELinux support and flakes enabled by default.
-
-!!! Warning
-    The Determinate Systems installer offers both official Nix and their own variant (Determinate Nix). When prompted, choose **official Nix**. System Manager is not tested against Determinate Nix.
-
-## Enabling Flakes
-
-The official installer does not enable flakes by default. Add this line to `/etc/nix/nix.conf`:
+The nix-installer enables flakes by default.
+If you installed Nix using a different installer, you may need to enable flakes manually by adding this line to `/etc/nix/nix.conf`:
 
 ```ini
 experimental-features = nix-command flakes


### PR DESCRIPTION
Replace references to Determinate Systems installer with official NixOS nix-installer. Remove multiple installation options in favor of single recommended approach. Update supported Nix version to 2.32+.