### PR TITLE
fix: add ipython dependency for interactive container test driver

### DIFF
--- a/lib/container-test-driver/package.nix
+++ b/lib/container-test-driver/package.nix
@@ -18,6 +18,7 @@ let
       python3Packages.colorama
       python3Packages.junit-xml
       python3Packages.ptpython
+      python3Packages.ipython
       python3Packages.pytest-testinfra
     ]
     ++ extraPythonPackages python3Packages;


### PR DESCRIPTION
ptpython.ipython requires IPython but ptpython does not propagate it as a dependency.