### PR TITLE
fix: ownership/permission on /etc/shadow from userborn PR

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -133,16 +133,16 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1770243776,
-        "narHash": "sha256-Nc7V8fmtW4but0LU0tEwjokRirDFuX6fmnmivmAvMZ8=",
+        "lastModified": 1770377964,
+        "narHash": "sha256-q2pnlX2IW0kg80GLFnwWd/GigIpkuZnyKPLhrgJql3E=",
         "owner": "jfroche",
         "repo": "userborn",
-        "rev": "9252a66ae12fff9f6e992310203a7aa763ba89ef",
+        "rev": "55c2cd7952c207a62736a5bbd9499ea73da18d24",
         "type": "github"
       },
       "original": {
         "owner": "jfroche",
-        "ref": "fix-existing-groups-members",
+        "ref": "system-manager",
         "repo": "userborn",
         "type": "github"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
 
   inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   inputs.userborn = {
-    url = "github:jfroche/userborn/fix-existing-groups-members";
+    url = "github:jfroche/userborn/system-manager";
     inputs.nixpkgs.follows = "nixpkgs";
   };
 

--- a/testFlake/flake.lock
+++ b/testFlake/flake.lock
@@ -198,16 +198,16 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1770243776,
-        "narHash": "sha256-Nc7V8fmtW4but0LU0tEwjokRirDFuX6fmnmivmAvMZ8=",
+        "lastModified": 1770377964,
+        "narHash": "sha256-q2pnlX2IW0kg80GLFnwWd/GigIpkuZnyKPLhrgJql3E=",
         "owner": "jfroche",
         "repo": "userborn",
-        "rev": "9252a66ae12fff9f6e992310203a7aa763ba89ef",
+        "rev": "55c2cd7952c207a62736a5bbd9499ea73da18d24",
         "type": "github"
       },
       "original": {
         "owner": "jfroche",
-        "ref": "fix-existing-groups-members",
+        "ref": "system-manager",
         "repo": "userborn",
         "type": "github"
       }

--- a/testFlake/vm-tests.nix
+++ b/testFlake/vm-tests.nix
@@ -344,6 +344,13 @@ forEachUbuntuImage "example" {
       assert "zimbatm" in sudo_entry, f"Expected zimbatm in sudo group, got: {sudo_entry}"
       assert "sudo" in zimbatm_groups, f"Expected zimbatm to be in sudo group, got: {zimbatm_groups}"
 
+      # Verify /etc/shadow has correct permissions after userborn activation
+      shadow_mode = vm.succeed("stat -c '%a' /etc/shadow").strip()
+      shadow_group = vm.succeed("stat -c '%G' /etc/shadow").strip()
+      print(f"Shadow permissions: mode={shadow_mode}, group={shadow_group}")
+      assert shadow_mode == "640", f"Expected /etc/shadow mode 640, got: {shadow_mode}"
+      assert shadow_group == "shadow", f"Expected /etc/shadow group shadow, got: {shadow_group}"
+
       zimbatm_shadow_before = vm.succeed("grep '^zimbatm:' /etc/shadow").strip()
       print(f"Shadow entry before deactivation: {zimbatm_shadow_before}")
       assert not zimbatm_shadow_before.startswith("zimbatm:!*"), f"Expected unlocked account before deactivation, got: {zimbatm_shadow_before}"
@@ -376,6 +383,13 @@ forEachUbuntuImage "example" {
       luj_shadow = vm.succeed("grep '^luj:' /etc/shadow").strip()
       print(f"Stateful user shadow after deactivation: {luj_shadow}")
       assert not luj_shadow.startswith("luj:!*"), f"Stateful user 'luj' should NOT be locked after deactivation, got: {luj_shadow}"
+
+      # Verify /etc/shadow permissions are preserved after deactivation
+      shadow_mode_after = vm.succeed("stat -c '%a' /etc/shadow").strip()
+      shadow_group_after = vm.succeed("stat -c '%G' /etc/shadow").strip()
+      print(f"Shadow permissions after deactivation: mode={shadow_mode_after}, group={shadow_group_after}")
+      assert shadow_mode_after == "640", f"Expected /etc/shadow mode 640 after deactivation, got: {shadow_mode_after}"
+      assert shadow_group_after == "shadow", f"Expected /etc/shadow group shadow after deactivation, got: {shadow_group_after}"
     '';
 }
 


### PR DESCRIPTION
We have added a PR to userborn to fix the ownership/permission on /etc/shadow: https://github.com/nikstur/userborn/pull/41

/etc/shadow has mode 0640 and group shadow after both activation and deactivation.

refs #350 