### PR TITLE
feat: add systemd.maskedUnits option

### DIFF
--- a/crates/system-manager-engine/src/systemd.rs
+++ b/crates/system-manager-engine/src/systemd.rs
@@ -263,6 +263,28 @@ impl ServiceManager {
         })
     }
 
+    pub fn mask_unit_files(&self, units: &[&str], runtime: bool) -> Result<(), Error> {
+        let changes = OrgFreedesktopSystemd1Manager::mask_unit_files(
+            &self.proxy,
+            units.to_vec(),
+            runtime,
+            true, // force: replace existing symlinks
+        )?;
+        for (change_type, from, to) in &changes {
+            log::debug!("Mask change: {change_type} {from} -> {to}");
+        }
+        Ok(())
+    }
+
+    pub fn unmask_unit_files(&self, units: &[&str], runtime: bool) -> Result<(), Error> {
+        let changes =
+            OrgFreedesktopSystemd1Manager::unmask_unit_files(&self.proxy, units.to_vec(), runtime)?;
+        for (change_type, from, to) in &changes {
+            log::debug!("Unmask change: {change_type} {from} -> {to}");
+        }
+        Ok(())
+    }
+
     pub fn list_units_by_patterns(
         &self,
         states: &[&str],

--- a/nix/modules/systemd.nix
+++ b/nix/modules/systemd.nix
@@ -141,6 +141,19 @@ in
       '';
     };
 
+    maskedUnits = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      example = [
+        "ssh.service"
+        "ModemManager.service"
+      ];
+      description = lib.mdDoc ''
+        Units to mask by symlinking to `/dev/null`. Use this for
+        distro-shipped units; for units you define, use `enable = false`
+      '';
+    };
+
     sysusers = {
       enable = lib.mkEnableOption "systemd-sysusers" // {
         description = ''

--- a/testFlake/container-tests.nix
+++ b/testFlake/container-tests.nix
@@ -109,4 +109,46 @@ in
             assert machine.file("/etc/tmpfiles.d/00-system-manager.conf").is_file, "00-system-manager.conf should exist"
       '';
   };
+
+  container-masked-units = makeContainerTestFor "masked-units" {
+    modules = [
+      (
+        { ... }:
+        {
+          systemd.maskedUnits = [ "unattended-upgrades.service" ];
+        }
+      )
+      ../examples/example.nix
+    ];
+    testScriptFunction =
+      { toplevel, hostPkgs, ... }:
+      ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+
+        with subtest("Service is not masked before activation"):
+            machine.fail("test -L /etc/systemd/system/unattended-upgrades.service")
+
+        with subtest("Service can be started before activation"):
+            assert machine.service("unattended-upgrades").is_running, "unattended-upgrades should be running before activation"
+
+        machine.activate()
+        machine.wait_for_unit("system-manager.target")
+
+        with subtest("Masked service is not running"):
+            assert not machine.service("unattended-upgrades").is_running, "unattended-upgrades should not be running"
+
+        with subtest("Service is masked after activation"):
+            resolved = machine.succeed("readlink -f /etc/systemd/system/unattended-upgrades.service").strip()
+            assert resolved == "/dev/null", f"expected /dev/null, got {resolved}"
+
+        with subtest("Masked service cannot be started"):
+            machine.fail("systemctl start unattended-upgrades.service")
+
+        with subtest("Deactivation unmasks the service"):
+            machine.succeed("${toplevel}/bin/deactivate")
+            machine.fail("test -L /etc/systemd/system/unattended-upgrades.service")
+      '';
+  };
 }


### PR DESCRIPTION
## summary

adds `systemd.maskedUnits` option to mask units shipped by the host distro (e.g.
`ssh.service` on ubuntu). masked units are symlinked to `/dev/null`, preventing
them from starting manually or as a dependency.

closes #306

## usage

```nix
{
  systemd.maskedUnits = [
    "ssh.service"
    "ModemManager.service"
  ];
}
```

## changes

- new `systemd.maskedUnits` list option in `systemd.nix`
- masked units included in `services.json` with `masked: true`
- assertion prevents overlap between defined units and masked units
- `ServiceConfig.store_path` is now `Option<StorePath>` for masked units
- activation stops masked services, skips them for reload/restart
- container test covers mask lifecycle

## design note

went with a top-level list rather than per-service
`systemd.services.<name>.mask = true` — the use case is masking units you don't
define yourself. for units you define, `enable = false` already works.