### PR TITLE
fix: update doc for userborn

### DIFF
--- a/docs/site/explanation/how-it-works.md
+++ b/docs/site/explanation/how-it-works.md
@@ -64,7 +64,6 @@ System Manager can manage:
 
 System Manager intentionally limits its scope:
 
-- **Users and groups** - Use your distro's tools
 - **Bootloader** - Managed by your distro
 - **Kernel** - Managed by your distro
 - **Files outside `/etc`** - Use environment.etc for `/etc` only

--- a/docs/site/explanation/nixos-comparison.md
+++ b/docs/site/explanation/nixos-comparison.md
@@ -19,7 +19,6 @@ If you're already running NixOS, you don't need System Manager - NixOS provides 
 | **Base system** | Nix all the way down | Your distro (Ubuntu, Debian, etc.) |
 | **Kernel** | Managed by Nix | Managed by distro |
 | **Bootloader** | Managed by Nix | Managed by distro |
-| **Users/Groups** | Managed declaratively | Managed by distro |
 | **Package manager** | Only Nix | Nix + distro's (apt, dnf, etc.) |
 | **Init system** | systemd (required) | systemd (required) |
 | **Rollback** | Full system rollback | Service/package rollback |
@@ -64,7 +63,6 @@ Some NixOS modules don't apply to System Manager:
 
 - `boot.*` - Bootloader configuration
 - `fileSystems.*` - Filesystem mounts
-- `users.users.*` - User management (though this may change)
 - Hardware-specific modules
 
 ## Migration Path
@@ -81,7 +79,7 @@ Some NixOS modules don't apply to System Manager:
 If you later decide to switch to NixOS:
 
 1. Your `.nix` configuration largely transfers over
-2. Add NixOS-specific modules (boot, filesystems, users)
+2. Add NixOS-specific modules (boot, filesystems)
 3. Install NixOS with your existing configuration as a base
 
 ### From NixOS to System Manager


### PR DESCRIPTION
There are some stale occurences stating that system-manager do not manage users and groups in the documentation. system-manager recently introduced declarative support for that through userborn.

Updating the doc.