### PR TITLE
feat: handle wildcards in environment.etc

### DIFF
--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -297,8 +297,16 @@
           addToStore =
             name: file:
             pkgs.runCommandLocal "${name}-etc-link" { } ''
-              mkdir -p "$out/$(dirname "${file.target}")"
-              ln -s "${file.source}" "$out/${file.target}"
+              if [[ "${file.source}" = *'*'* ]]; then
+                # If the target name contains '*', perform globbing.
+                mkdir -p "$out/${file.target}"
+                for fn in ${file.source}; do
+                    ln -s "$fn" "$out/${file.target}/"
+                done
+              else
+                mkdir -p "$out/$(dirname "${file.target}")"
+                ln -s "${file.source}" "$out/${file.target}"
+              fi
             '';
 
           filteredEntries = lib.filterAttrs (_name: etcFile: etcFile.enable) config.environment.etc;

--- a/testFlake/container-tests.nix
+++ b/testFlake/container-tests.nix
@@ -151,4 +151,32 @@ in
             machine.fail("test -L /etc/systemd/system/unattended-upgrades.service")
       '';
   };
+  container-etc-files-with-glob = makeContainerTestFor "etc-files-with-glob" {
+    modules = [
+      (
+        { pkgs, ... }:
+        {
+          environment.etc = {
+            "fail2ban/action.d".source = "${pkgs.fail2ban}/etc/fail2ban/action.d/*.conf";
+            "fail2ban/filter.d".source = "${pkgs.fail2ban}/etc/fail2ban/filter.d/*.conf";
+          };
+        }
+      )
+    ];
+    testScriptFunction =
+      { toplevel, hostPkgs, ... }:
+      ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+
+        with subtest("File from glob is not present"):
+            machine.fail("test -f /etc/fail2ban/action.d/dummy.conf")
+
+        machine.activate()
+
+        with subtest("File from glob is present"):
+            machine.succeed("test -f /etc/fail2ban/action.d/dummy.conf")
+      '';
+  };
 }


### PR DESCRIPTION
Reuse NixOS code to handle wildcards in `environment.etc`, which allows us to easily link multiple files from a package into /etc.