### PR TITLE
systemd unit generation: allow systemd unit overrides

### DIFF
--- a/nix/modules/systemd.nix
+++ b/nix/modules/systemd.nix
@@ -215,8 +215,6 @@ in
 
     environment.etc =
       let
-        allowCollisions = false;
-
         enabledUnits = lib.filterAttrs (_: unit: unit.enable) cfg.units;
       in
       {
@@ -245,18 +243,8 @@ in
                   if [ "$(readlink -f $i/$fn)" = /dev/null ]; then
                     ln -sfn /dev/null $out/$fn
                   else
-                    ${
-                      if allowCollisions then
-                        ''
-                          mkdir -p $out/$fn.d
-                          ln -s $i/$fn $out/$fn.d/overrides.conf
-                        ''
-                      else
-                        ''
-                          echo "Found multiple derivations configuring $fn!"
-                          exit 1
-                        ''
-                    }
+                    mkdir -p $out/$fn.d
+                    ln -s $i/$fn $out/$fn.d/overrides.conf
                   fi
                 else
                   ln -fs $i/$fn $out/

--- a/testFlake/container-tests.nix
+++ b/testFlake/container-tests.nix
@@ -4,6 +4,7 @@
   system-manager,
   system,
   hostPkgs,
+  nixpkgs,
 }:
 
 let
@@ -194,7 +195,33 @@ in
       (
         { pkgs, ... }:
         {
-          systemd.packages = [ pkgs.fail2ban ];
+          imports = [ "${nixpkgs}/nixos/modules/services/security/fail2ban.nix" ];
+          config = {
+
+            # Enabling fail2ban to test systemd units overrides and
+            # systemd.packages options.
+            services.fail2ban = {
+              enable = true;
+              bantime = "3600";
+              packageFirewall = pkgs.nftables;
+            };
+            networking.nftables.enable = true;
+
+            systemd.services.fail2ban = {
+              wantedBy = lib.mkForce [
+                "system-manager.target"
+              ];
+            };
+          };
+          options = {
+            # Dummy valies to enable fail2ban
+            services.openssh.settings = lib.mkOption {
+              type = lib.types.attrs;
+            };
+            # Some goes for nftables
+            networking.nftables.enable = lib.mkEnableOption "dummy nftable module";
+          };
+
         }
       )
     ];
@@ -212,6 +239,7 @@ in
             unit = machine.file("/etc/systemd/system/fail2ban.service")
             assert unit.exists, "fail2ban.service unit file should exist"
             assert unit.is_symlink or unit.is_file, "fail2ban.service should be a file or symlink"
+            machine.wait_for_unit("fail2ban.service")
       '';
   };
 }

--- a/testFlake/flake.nix
+++ b/testFlake/flake.nix
@@ -49,7 +49,7 @@
       containerChecks =
         system:
         import ./container-tests.nix {
-          inherit system;
+          inherit nixpkgs system;
           inherit (nixpkgs) lib;
           hostPkgs = nixpkgs.legacyPackages.${system};
           inherit system-manager;


### PR DESCRIPTION
The unit generation script has been vendored from Nixpkgs. In Nixpkgs, there's a "allowCollisions" flag that when enabled, will create a systemd override file if there's a unit name collision.

It's enabled for the generation of systemd units but disabled for the generation of systemd-nspawn unit. Systemd-nspawn do not support this override mechanism.

In the system-manager case, overrides are always supported, there is no need for such a flag.

Removing the flag, removing the "false" condition branch.

Adding a fail2ban test which do test both the systemd.packages option and the override mechanism.