### PR TITLE
fix: increase timeout for dbus calls to 10 seconds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 **/.nixos-test-history
 
 detailed_errors.txt
+
+vendor

--- a/crates/system-manager-engine/src/systemd.rs
+++ b/crates/system-manager-engine/src/systemd.rs
@@ -106,7 +106,7 @@ impl ServiceManager {
         let proxy = Proxy::new(
             SD_DESTINATION,
             SD_PATH,
-            Duration::from_secs(2),
+            Duration::from_secs(10),
             Box::new(conn),
         );
 
@@ -138,7 +138,7 @@ impl ServiceManager {
         OrgFreedesktopSystemd1Manager::reload(&self.proxy)?;
 
         while !ready.load(Ordering::Relaxed) {
-            self.proxy.connection.process(Duration::from_secs(2))?;
+            self.proxy.connection.process(Duration::from_secs(10))?;
         }
 
         Ok(())


### PR DESCRIPTION
We sometimes have systemd daemon reloads that take a long time, and the current timeout of 2 seconds is too short. This commit increases the timeout to 10 seconds.