### PR TITLE
tests: add direnv integration test

### DIFF
--- a/testFlake/container-tests/upstream-packages.nix
+++ b/testFlake/container-tests/upstream-packages.nix
@@ -5,14 +5,17 @@
   ...
 }:
 
-forEachDistro "systemd-packages" {
+forEachDistro "upstream-packages" {
   modules = [
     (
       { pkgs, ... }:
       {
-        imports = [ "${nixpkgs}/nixos/modules/services/security/fail2ban.nix" ];
+        imports = [
+          "${nixpkgs}/nixos/modules/services/security/fail2ban.nix"
+          "${nixpkgs}/nixos/modules/programs/direnv.nix"
+        ];
         config = {
-
+          programs.direnv.enable = true;
           # Enabling fail2ban to test systemd units overrides and
           # systemd.packages options.
           services.fail2ban = {
@@ -26,7 +29,6 @@ forEachDistro "systemd-packages" {
           # Some goes for nftables
           networking.nftables.enable = lib.mkEnableOption "dummy nftable module";
         };
-
       }
     )
   ];
@@ -45,5 +47,10 @@ forEachDistro "systemd-packages" {
           assert unit.exists, "fail2ban.service unit file should exist"
           assert unit.is_symlink or unit.is_file, "fail2ban.service should be a file or symlink"
           machine.wait_for_unit("fail2ban.service")
+
+      with subtest ("Direnv integration should work"):
+          machine.succeed("test -f /etc/direnv/direnv.toml")
+          machine.succeed("test -f /etc/direnv/direnvrc")
+          machine.succeed("which direnv")
     '';
 }


### PR DESCRIPTION
Making sure upstream direnv module works as intended.

Note: drafted at the moment, blocked by https://github.com/numtide/system-manager/issues/225