### PR TITLE
feat: add boot.kernel.sysctl and boot.kernelModules

### DIFF
--- a/crates/system-manager-engine/src/activate/etc_files.rs
+++ b/crates/system-manager-engine/src/activate/etc_files.rs
@@ -234,13 +234,18 @@ fn list_static_entries(config_entries: &EtcFilesConfig) -> anyhow::Result<Vec<Et
             // that may not resolve inside the Nix store because the target unit
             // can come from the host system (asDropin strategy). Read the symlink
             // target directly and store it as the source instead of canonicalizing.
-            let target_is_systemd_dep = is_inside_systemd_dependency_dir(&PathBuf::from("/etc").join(&target_path));
+            let target_is_systemd_dep =
+                is_inside_systemd_dependency_dir(&PathBuf::from("/etc").join(&target_path));
             if target_is_systemd_dep && file_path.is_symlink() {
                 let link_target = fs::read_link(&file_path).context(format!(
                     "Failed to read symlink target of {}",
                     file_path.display()
                 ))?;
-                log::debug!("{} is a dependency symlink -> {}", file_path.display(), link_target.display());
+                log::debug!(
+                    "{} is a dependency symlink -> {}",
+                    file_path.display(),
+                    link_target.display()
+                );
                 let replace_existing = config_entries
                     .entries
                     .iter()

--- a/crates/system-manager-engine/src/activate/etc_files.rs
+++ b/crates/system-manager-engine/src/activate/etc_files.rs
@@ -228,34 +228,30 @@ fn list_static_entries(config_entries: &EtcFilesConfig) -> anyhow::Result<Vec<Et
         let dir_content = fs::read_dir(&dir.absolute_path)?;
         for file in dir_content {
             let file = file?;
-            let canon_path = fs::canonicalize(file.path()).context(format!(
-                "Failed to get the canonical path of {}",
-                file.path().display()
-            ))?;
-            if canon_path.is_dir() {
-                log::debug!("{} is a dir", canon_path.display());
-                let dirname = file.file_name();
-                let mut path_from_root = dir.path_from_root.clone();
-                path_from_root.push(dirname);
-                dirs_to_visit.push(DirToVisit {
-                    absolute_path: canon_path,
-                    path_from_root,
-                });
-            } else {
-                log::debug!("{} is a file", file.path().display());
-                let target = dir.path_from_root.clone().join(file.file_name());
-                // Is this file entry available in the config? If so, inherit replace_existing.
+            let file_path = file.path();
+            let target_path = dir.path_from_root.clone().join(file.file_name());
+            // .wants/.requires symlinks use relative targets (e.g. ../unit.service)
+            // that may not resolve inside the Nix store because the target unit
+            // can come from the host system (asDropin strategy). Read the symlink
+            // target directly and store it as the source instead of canonicalizing.
+            let target_is_systemd_dep = is_inside_systemd_dependency_dir(&PathBuf::from("/etc").join(&target_path));
+            if target_is_systemd_dep && file_path.is_symlink() {
+                let link_target = fs::read_link(&file_path).context(format!(
+                    "Failed to read symlink target of {}",
+                    file_path.display()
+                ))?;
+                log::debug!("{} is a dependency symlink -> {}", file_path.display(), link_target.display());
                 let replace_existing = config_entries
                     .entries
                     .iter()
-                    .find(|e| e.1.target == target)
+                    .find(|e| e.1.target == target_path)
                     .map(|e| e.1.replace_existing)
                     .unwrap_or(false);
                 let etc_file = EtcFile {
                     source: StorePath {
-                        store_path: canon_path,
+                        store_path: link_target,
                     },
-                    target: PathBuf::from("/etc").join(target),
+                    target: PathBuf::from("/etc").join(target_path),
                     uid: 0,
                     gid: 0,
                     group: "".to_string(),
@@ -264,12 +260,53 @@ fn list_static_entries(config_entries: &EtcFilesConfig) -> anyhow::Result<Vec<Et
                     replace_existing,
                 };
                 log::debug!(
-                    "add file: {:?}, path_from_root: {:?}, absolute_path: {:?}",
+                    "add dependency symlink: {:?}, path_from_root: {:?}",
                     etc_file,
-                    dir.path_from_root,
-                    dir.absolute_path
+                    dir.path_from_root
                 );
                 files.push(etc_file);
+            } else {
+                let canon_path = fs::canonicalize(&file_path).context(format!(
+                    "Failed to get the canonical path of {}",
+                    file_path.display()
+                ))?;
+                if canon_path.is_dir() {
+                    log::debug!("{} is a dir", canon_path.display());
+                    let dirname = file.file_name();
+                    let mut path_from_root = dir.path_from_root.clone();
+                    path_from_root.push(dirname);
+                    dirs_to_visit.push(DirToVisit {
+                        absolute_path: canon_path,
+                        path_from_root,
+                    });
+                } else {
+                    log::debug!("{} is a file", file_path.display());
+                    let replace_existing = config_entries
+                        .entries
+                        .iter()
+                        .find(|e| e.1.target == target_path)
+                        .map(|e| e.1.replace_existing)
+                        .unwrap_or(false);
+                    let etc_file = EtcFile {
+                        source: StorePath {
+                            store_path: canon_path,
+                        },
+                        target: PathBuf::from("/etc").join(target_path),
+                        uid: 0,
+                        gid: 0,
+                        group: "".to_string(),
+                        user: "".to_string(),
+                        mode: "symlink".to_string(),
+                        replace_existing,
+                    };
+                    log::debug!(
+                        "add file: {:?}, path_from_root: {:?}, absolute_path: {:?}",
+                        etc_file,
+                        dir.path_from_root,
+                        dir.absolute_path
+                    );
+                    files.push(etc_file);
+                }
             }
         }
         i += 1;

--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -103,6 +103,13 @@
         Setting a variable to `null` does nothing. You can override a
         variable set by another module to `null` to unset it.
 
+        Unlike [](#opt-environment.variables), session variables will
+        append the existing value of the variable using the
+        `''${parameter:+word}` shell expansion. For example, setting
+        `XDG_DATA_DIRS` to `"/nix/share"` will produce
+        `export XDG_DATA_DIRS="/nix/share''${XDG_DATA_DIRS:+:''$XDG_DATA_DIRS}"`,
+        which preserves any pre-existing value.
+
         Note: unlike NixOS, system-manager does not manage PAM on the
         host, so these variables are not injected by pam_env into
         non-shell sessions (e.g. graphical logins).
@@ -125,6 +132,15 @@
   config =
     let
       pathDir = "/run/system-manager/sw";
+
+      sessionVarNames = builtins.attrNames config.environment.sessionVariables;
+
+      exportLine =
+        k: v:
+        if builtins.elem k sessionVarNames then
+          "export ${k}=\"" + v + "$\{" + k + ":+:$" + k + "}\""
+        else
+          "export ${k}=\"" + v + "\"";
     in
     {
       environment = {
@@ -138,7 +154,7 @@
 
         etc = {
           "profile.d/system-manager-path.sh".source = pkgs.writeText "system-manager-path.sh" ''
-            ${lib.concatLines (lib.mapAttrsToList (k: v: ''export ${k}="${v}"'') config.environment.variables)}
+            ${lib.concatLines (lib.mapAttrsToList exportLine config.environment.variables)}
             export PATH=${pathDir}/bin:''${PATH}
             if [ -d "/etc/profiles/per-user/$USER/bin" ]; then
               export PATH="/etc/profiles/per-user/$USER/bin:$PATH"

--- a/nix/modules/systemd.nix
+++ b/nix/modules/systemd.nix
@@ -259,7 +259,15 @@ in
                 done
               done
 
-              for i in ${toString (lib.mapAttrsToList (n: v: v.unit) enabledUnits)}; do
+              for i in ${
+                toString (
+                  lib.mapAttrsToList (n: v: v.unit) (
+                    lib.filterAttrs (
+                      n: v: (lib.attrByPath [ "overrideStrategy" ] "asDropinIfExists" v) == "asDropinIfExists"
+                    ) enabledUnits
+                  )
+                )
+              }; do
                 fn=$(basename $i/*)
                 if [ -e $out/$fn ]; then
                   if [ "$(readlink -f $i/$fn)" = /dev/null ]; then
@@ -271,6 +279,18 @@ in
                 else
                   ln -fs $i/$fn $out/
                 fi
+              done
+
+              for i in ${
+                toString (
+                  lib.mapAttrsToList (n: v: v.unit) (
+                    lib.filterAttrs (n: v: v ? overrideStrategy && v.overrideStrategy == "asDropin") enabledUnits
+                  )
+                )
+              }; do
+                fn=$(basename $i/*)
+                mkdir -p $out/$fn.d
+                ln -s $i/$fn $out/$fn.d/overrides.conf
               done
 
               ${lib.concatStrings (

--- a/nix/modules/systemd.nix
+++ b/nix/modules/systemd.nix
@@ -253,7 +253,7 @@ in
 
               for package in $packages
               do
-                for hook in $package/lib/systemd/system/*
+                for hook in $package/etc/systemd/system/* $package/lib/systemd/system/*
                 do
                   ln -s $hook $out/
                 done

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -123,8 +123,8 @@ in
         };
       };
 
-      systemd-sysctl.overrideStrategy = "asDropin";
-      systemd-sysctl = {
+      systemd-sysctl = lib.mkIf (config.environment.etc ? "sysctl.d/60-nixos.conf") {
+        overrideStrategy = "asDropin";
         wantedBy = [
           "system-manager.target"
           "multi-user.target"

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -110,25 +110,27 @@ in
       "modules-load.d/system-manager.conf".source = kernelModulesConf;
     };
 
-    systemd.services.systemd-modules-load.overrideStrategy = "asDropin";
-    systemd.services.systemd-modules-load = {
-      wantedBy = [
-        "system-manager.target"
-        "multi-user.target"
-      ];
-      restartTriggers = [ kernelModulesConf ];
-      serviceConfig = {
-        SuccessExitStatus = "0 1";
+    systemd.services = {
+      systemd-modules-load = lib.mkIf (config.boot.kernelModules != [ ]) {
+        overrideStrategy = "asDropin";
+        wantedBy = [
+          "system-manager.target"
+          "multi-user.target"
+        ];
+        restartTriggers = [ kernelModulesConf ];
+        serviceConfig = {
+          SuccessExitStatus = "0 1";
+        };
       };
-    };
 
-    systemd.services.systemd-sysctl.overrideStrategy = "asDropin";
-    systemd.services.systemd-sysctl = {
-      wantedBy = [
-        "system-manager.target"
-        "multi-user.target"
-      ];
-      restartTriggers = [ config.environment.etc."sysctl.d/60-nixos.conf".source ];
+      systemd-sysctl.overrideStrategy = "asDropin";
+      systemd-sysctl = {
+        wantedBy = [
+          "system-manager.target"
+          "multi-user.target"
+        ];
+        restartTriggers = [ config.environment.etc."sysctl.d/60-nixos.conf".source ];
+      };
     };
   };
 }

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -28,6 +28,7 @@ in
     ./programs/ssh.nix
     ./security-wrappers.nix
     ./security/sudo.nix
+    ./sysctl.nix
     ./userborn.nix
     ./users-groups.nix
     ../sops-nix.nix
@@ -44,7 +45,6 @@ in
       "/security/sudo.nix"
       "/security/wrappers/"
       "/services/web-servers/nginx/"
-      "/config/sysctl.nix"
       # nix settings
       "/config/nix.nix"
       "/services/system/userborn.nix"
@@ -121,11 +121,6 @@ in
         serviceConfig = {
           SuccessExitStatus = "0 1";
         };
-      };
-
-      systemd-sysctl = {
-        overrideStrategy = "asDropin";
-        wantedBy = [ "system-manager.target" ];
       };
     };
   };

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -12,7 +12,7 @@ let
     be included. Note that setting these names to `false` does not
     prevent the module from being loaded.
   '';
-  kernelModulesConf = pkgs.writeText "nixos.conf" ''
+  kernelModulesConf = pkgs.writeText "system-manager.conf" ''
     ${lib.concatStringsSep "\n" config.boot.kernelModules}
   '';
   attrNamesToTrue = lib.types.coercedTo (lib.types.listOf lib.types.str) (
@@ -106,7 +106,7 @@ in
   config = {
     # Create /etc/modules-load.d/system-manager.conf, which is read by
     # systemd-modules-load.service to load required kernel modules.
-    environment.etc = lib.mkIf (config.boot.kernelModules != { }) {
+    environment.etc = lib.mkIf (config.boot.kernelModules != [ ]) {
       "modules-load.d/system-manager.conf".source = kernelModulesConf;
     };
 
@@ -123,13 +123,9 @@ in
         };
       };
 
-      systemd-sysctl = lib.mkIf (config.environment.etc ? "sysctl.d/60-nixos.conf") {
+      systemd-sysctl = {
         overrideStrategy = "asDropin";
-        wantedBy = [
-          "system-manager.target"
-          "multi-user.target"
-        ];
-        restartTriggers = [ config.environment.etc."sysctl.d/60-nixos.conf".source ];
+        wantedBy = [ "system-manager.target" ];
       };
     };
   };

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -2,8 +2,23 @@
   nixosModulesPath,
   lib,
   pkgs,
+  config,
   ...
 }:
+let
+  modulesTypeDesc = ''
+    This can either be a list of modules, or an attrset. In an
+    attrset, names that are set to `true` represent modules that will
+    be included. Note that setting these names to `false` does not
+    prevent the module from being loaded.
+  '';
+  kernelModulesConf = pkgs.writeText "nixos.conf" ''
+    ${lib.concatStringsSep "\n" config.boot.kernelModules}
+  '';
+  attrNamesToTrue = lib.types.coercedTo (lib.types.listOf lib.types.str) (
+    enabledList: lib.genAttrs enabledList (_attrName: true)
+  ) (lib.types.attrsOf lib.types.bool);
+in
 {
   imports = [
     ./dhparams.nix
@@ -29,6 +44,7 @@
       "/security/sudo.nix"
       "/security/wrappers/"
       "/services/web-servers/nginx/"
+      "/config/sysctl.nix"
       # nix settings
       "/config/nix.nix"
       "/services/system/userborn.nix"
@@ -38,11 +54,27 @@
   options =
     # We need to ignore a bunch of options that are used in NixOS modules but
     # that don't apply to system-manager configs.
-    # TODO: can we print an informational message for things like kernel modules
-    # to inform users that they need to be enabled in the host system?
     {
-      boot = lib.mkOption {
-        type = lib.types.raw;
+      boot = {
+        kernelModules = lib.mkOption {
+          type = attrNamesToTrue;
+          default = { };
+          description = ''
+            The set of kernel modules to be loaded in the second stage of
+            the boot process.
+
+            ${modulesTypeDesc}
+          '';
+          apply = mods: lib.attrNames (lib.filterAttrs (_: v: v) mods);
+        };
+
+        kernelPackages = lib.mkOption {
+          type = lib.types.raw;
+          default = {
+            kernel.version = "stub";
+          };
+          description = "Stub kernel packages for compatibility; not actively used in system-manager.";
+        };
       };
 
       # nixos/modules/services/system/userborn.nix still depends on activation scripts
@@ -70,4 +102,17 @@
         defaultText = lib.literalExpression "pkgs.glibcLocales";
       };
     };
+
+  config = {
+    # Create /etc/modules-load.d/system-manager.conf, which is read by
+    # systemd-modules-load.service to load required kernel modules.
+    environment.etc = lib.mkIf (config.boot.kernelModules != { }) {
+      "modules-load.d/system-manager.conf".source = kernelModulesConf;
+    };
+
+    # config/sysctl.nix assumes it can freely configure systemd-sysctl.service.
+    # However, in our case, the service is managed by the host system,
+    # so we default to enable = false; to avoid unintended interference.
+    systemd.services.systemd-sysctl.enable = lib.mkDefault false;
+  };
 }

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -110,9 +110,25 @@ in
       "modules-load.d/system-manager.conf".source = kernelModulesConf;
     };
 
-    # config/sysctl.nix assumes it can freely configure systemd-sysctl.service.
-    # However, in our case, the service is managed by the host system,
-    # so we default to enable = false; to avoid unintended interference.
-    systemd.services.systemd-sysctl.enable = lib.mkDefault false;
+    systemd.services.systemd-modules-load.overrideStrategy = "asDropin";
+    systemd.services.systemd-modules-load = {
+      wantedBy = [
+        "system-manager.target"
+        "multi-user.target"
+      ];
+      restartTriggers = [ kernelModulesConf ];
+      serviceConfig = {
+        SuccessExitStatus = "0 1";
+      };
+    };
+
+    systemd.services.systemd-sysctl.overrideStrategy = "asDropin";
+    systemd.services.systemd-sysctl = {
+      wantedBy = [
+        "system-manager.target"
+        "multi-user.target"
+      ];
+      restartTriggers = [ config.environment.etc."sysctl.d/60-nixos.conf".source ];
+    };
   };
 }

--- a/nix/modules/upstream/nixpkgs/sysctl.nix
+++ b/nix/modules/upstream/nixpkgs/sysctl.nix
@@ -1,0 +1,82 @@
+{
+  config,
+  lib,
+  ...
+}:
+let
+
+  sysctlOption = lib.mkOptionType {
+    name = "sysctl option value";
+    check =
+      val:
+      let
+        checkType = x: lib.isBool x || lib.isString x || lib.isInt x || x == null;
+      in
+      checkType val || (val._type or "" == "override" && checkType val.content);
+    merge = loc: defs: lib.mergeOneOption loc defs;
+  };
+
+in
+{
+
+  options = {
+
+    boot.kernel.sysctl = lib.mkOption {
+      type =
+        let
+          highestValueType = lib.types.ints.unsigned // {
+            merge = loc: defs: lib.foldl (a: b: if b.value == null then null else lib.max a b.value) 0 defs;
+          };
+        in
+        lib.types.submodule {
+          freeformType = lib.types.attrsOf sysctlOption;
+          options = {
+            "net.core.rmem_max" = lib.mkOption {
+              type = lib.types.nullOr highestValueType;
+              default = null;
+              description = "The maximum receive socket buffer size in bytes. In case of conflicting values, the highest will be used.";
+            };
+
+            "net.core.wmem_max" = lib.mkOption {
+              type = lib.types.nullOr highestValueType;
+              default = null;
+              description = "The maximum send socket buffer size in bytes. In case of conflicting values, the highest will be used.";
+            };
+          };
+        };
+      default = { };
+      example = lib.literalExpression ''
+        { "net.ipv4.tcp_syncookies" = false; "vm.swappiness" = 60; }
+      '';
+      description = ''
+        Runtime parameters of the Linux kernel, as set by
+        {manpage}`sysctl(8)`.  Note that sysctl
+        parameters names must be enclosed in quotes
+        (e.g. `"vm.swappiness"` instead of
+        `vm.swappiness`).  The value of each
+        parameter may be a string, integer, boolean, or null
+        (signifying the option will not appear at all).
+      '';
+
+    };
+
+  };
+
+  config = {
+
+    environment.etc = lib.mkIf (config.boot.kernel.sysctl != { }) {
+      "sysctl.d/60-system-manager.conf".text = lib.concatStrings (
+        lib.mapAttrsToList (
+          n: v: lib.optionalString (v != null) "${n}=${if v == false then "0" else toString v}\n"
+        ) config.boot.kernel.sysctl
+      );
+    };
+
+    systemd.services.systemd-sysctl = lib.mkIf (config.boot.kernel.sysctl != { }) {
+      overrideStrategy = "asDropin";
+      wantedBy = [ "system-manager.target" ];
+      restartTriggers = [ config.environment.etc."sysctl.d/60-system-manager.conf".source ];
+    };
+
+  };
+}

--- a/testFlake/container-tests/environment-variables.nix
+++ b/testFlake/container-tests/environment-variables.nix
@@ -17,6 +17,10 @@ forEachDistro "environment-variables" {
 
         environment.sessionVariables = {
           SESSION_VAR = "from-session";
+          XDG_DATA_DIRS = [
+            "/nix/share1"
+            "/nix/share2"
+          ];
         };
 
         environment.systemPackages = [ pkgs.hello ];
@@ -54,6 +58,22 @@ forEachDistro "environment-variables" {
       with subtest("sessionVariables are login shell exports"):
           value = machine.succeed("bash --login -c 'echo $SESSION_VAR'").strip()
           assert value == "from-session", f"Expected 'from-session', got: '{value}'"
+
+      with subtest("sessionVariables append existing values"):
+          value = machine.succeed("bash --login -c 'SESSION_VAR=existing; export SESSION_VAR; source /etc/profile.d/system-manager-path.sh; echo $SESSION_VAR'").strip()
+          assert value == "from-session:existing", f"Expected 'from-session:existing', got: '{value}'"
+
+      with subtest("sessionVariables with list value append existing values"):
+          value = machine.succeed("bash --login -c 'XDG_DATA_DIRS=/host/share; export XDG_DATA_DIRS; source /etc/profile.d/system-manager-path.sh; echo $XDG_DATA_DIRS'").strip()
+          assert value == "/nix/share1:/nix/share2:/host/share", f"Expected '/nix/share1:/nix/share2:/host/share', got: '{value}'"
+
+      with subtest("sessionVariables with list value works without pre-existing value"):
+          value = machine.succeed("bash --login -c 'unset XDG_DATA_DIRS; source /etc/profile.d/system-manager-path.sh; echo $XDG_DATA_DIRS'").strip()
+          assert value == "/nix/share1:/nix/share2", f"Expected '/nix/share1:/nix/share2', got: '{value}'"
+
+      with subtest("environment.variables overwrite existing values"):
+          value = machine.succeed("bash --login -c 'FOO=existing; export FOO; source /etc/profile.d/system-manager-path.sh; echo $FOO'").strip()
+          assert value == "bar", f"Expected 'bar', got: '{value}'"
 
       with subtest("extraSetup removes binary from system PATH"):
           machine.fail("test -e /run/system-manager/sw/bin/hello")

--- a/testFlake/container-tests/systemd-override-strategy.nix
+++ b/testFlake/container-tests/systemd-override-strategy.nix
@@ -1,0 +1,87 @@
+{ forEachDistro, ... }:
+
+forEachDistro "systemd-override-strategy" {
+  modules = [
+    (
+      { pkgs, ... }:
+      let
+        etcOnlyUnit = pkgs.writeTextDir "etc/systemd/system/etc-only.service" ''
+          [Unit]
+          Description=Unit shipped from etc/systemd/system
+
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/sh -c 'touch /run/etc-only-service-started'
+        '';
+
+        asDropinBaseUnit = pkgs.writeTextDir "etc/systemd/system/as-dropin.service" ''
+          [Unit]
+          Description=Base unit from package (asDropin)
+
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/true
+        '';
+
+        asDropinIfExistsBaseUnit = pkgs.writeTextDir "lib/systemd/system/as-if-exists.service" ''
+          [Unit]
+          Description=Base unit from package (asDropinIfExists)
+
+          [Service]
+          Type=oneshot
+          ExecStart=/bin/true
+        '';
+      in
+      {
+        systemd.packages = [
+          etcOnlyUnit
+          asDropinBaseUnit
+          asDropinIfExistsBaseUnit
+        ];
+
+        systemd.services = {
+          as-dropin = {
+            enable = true;
+            overrideStrategy = "asDropin";
+            description = "Override generated as explicit drop-in";
+            script = ''
+              echo "as-dropin override"
+            '';
+          };
+
+          as-if-exists = {
+            enable = true;
+            description = "Override generated as drop-in only if base unit exists";
+            script = ''
+              echo "as-if-exists override"
+            '';
+          };
+        };
+      }
+    )
+  ];
+  testScriptFunction =
+    { toplevel, hostPkgs, ... }:
+    ''
+      start_all()
+      machine.wait_for_unit("multi-user.target")
+
+      machine.activate()
+      machine.wait_for_unit("system-manager.target")
+
+      with subtest("Unit file from package etc/systemd/system is copied"):
+          unit = machine.file("/etc/systemd/system/etc-only.service")
+          assert unit.exists, "etc-only.service should exist"
+          assert unit.is_symlink or unit.is_file, "etc-only.service should be a file or symlink"
+          machine.succeed("systemctl start etc-only.service")
+          machine.succeed("test -f /run/etc-only-service-started")
+
+      with subtest("overrideStrategy=asDropin produces a drop-in"):
+          machine.succeed("test -L /etc/systemd/system/as-dropin.service")
+          machine.succeed("test -L /etc/systemd/system/as-dropin.service.d/overrides.conf")
+
+      with subtest("default overrideStrategy behaves as asDropinIfExists"):
+          machine.succeed("test -L /etc/systemd/system/as-if-exists.service")
+          machine.succeed("test -L /etc/systemd/system/as-if-exists.service.d/overrides.conf")
+    '';
+}

--- a/testFlake/vm-tests/boot-config.nix
+++ b/testFlake/vm-tests/boot-config.nix
@@ -1,0 +1,74 @@
+{
+  forEachImage,
+  system-manager,
+  system,
+  ...
+}:
+
+let
+  emptyConfig = system-manager.lib.makeSystemConfig {
+    modules = [
+      {
+        nixpkgs.hostPlatform = system;
+      }
+    ];
+  };
+in
+forEachImage "boot-config" {
+  modules = [
+    (
+      { ... }:
+      {
+        boot.kernel.sysctl = {
+          "net.ipv4.ip_forward" = 1;
+          "vm.swappiness" = 10;
+        };
+        boot.kernelModules = [ "veth" ];
+      }
+    )
+  ];
+  extraPathsToRegister = [ emptyConfig ];
+  testScriptFunction =
+    { toplevel, hostPkgs, ... }:
+    ''
+      start_all()
+      vm.wait_for_unit("default.target")
+
+      # Activate empty config: modules-load.d config should not be created
+      ${system-manager.lib.activateProfileSnippet {
+        node = "vm";
+        profile = emptyConfig;
+      }}
+      vm.wait_for_unit("system-manager.target")
+
+      vm.fail("test -f /etc/modules-load.d/system-manager.conf")
+      vm.fail("test -d /etc/systemd/system/systemd-modules-load.service.d")
+      # sysctl drop-in exists even without explicit config (upstream defaults)
+      vm.succeed("test -e /etc/systemd/system/systemd-sysctl.service.d/overrides.conf")
+
+      # Activate with kernel modules: config should exist
+      ${system-manager.lib.activateProfileSnippet {
+        node = "vm";
+        profile = toplevel;
+      }}
+      vm.wait_for_unit("system-manager.target")
+
+      vm.succeed("test -f /etc/modules-load.d/system-manager.conf")
+      vm.succeed("grep -q veth /etc/modules-load.d/system-manager.conf")
+      vm.succeed("test -e /etc/systemd/system/systemd-modules-load.service.d/overrides.conf")
+
+      # Verify sysctl config file
+      vm.succeed("test -f /etc/sysctl.d/60-nixos.conf")
+      vm.succeed("grep -q net.ipv4.ip_forward /etc/sysctl.d/60-nixos.conf")
+      vm.succeed("grep -q vm.swappiness /etc/sysctl.d/60-nixos.conf")
+      vm.succeed("test -e /etc/systemd/system/systemd-sysctl.service.d/overrides.conf")
+
+      ip_forward = vm.succeed("sysctl -n net.ipv4.ip_forward").strip()
+      assert ip_forward == "1", f"Expected net.ipv4.ip_forward=1, got {ip_forward}"
+
+      swappiness = vm.succeed("sysctl -n vm.swappiness").strip()
+      assert swappiness == "10", f"Expected vm.swappiness=10, got {swappiness}"
+
+      vm.succeed("lsmod | grep -q veth")
+    '';
+}


### PR DESCRIPTION
Implement #382 and make `boot` more extensible. To maintain backward compatibility and ensure the tests pass, `boot.kernelPackages.kernel.version` is also stubbed. Some potential side effects are: if users import other modules that access additional `boot` attributes downstream and those are not stubbed in this PR, they will need to provide stub values under `boot` themselves.