### PR TITLE
fix: do not override system shadow utilities

### DIFF
--- a/nix/modules/upstream/nixpkgs/users-groups.nix
+++ b/nix/modules/upstream/nixpkgs/users-groups.nix
@@ -260,8 +260,8 @@ let
 
         shell = mkOption {
           type = types.nullOr (types.either types.shellPackage (types.passwdEntry types.path));
-          default = pkgs.shadow;
-          defaultText = literalExpression "pkgs.shadow";
+          default = nologinPackage;
+          defaultText = literalExpression "nologinPackage";
           example = literalExpression "pkgs.bashInteractive";
           description = ''
             The path to the user's shell. Can use shell derivations,
@@ -656,6 +656,19 @@ let
     }
   );
 
+  # Provide only nologin from the shadow suite.
+  # The full pkgs.shadow must not end up in systemPackages because its
+  # binaries (passwd, su, chsh, etc.) are linked against nix store PAM
+  # libraries and are incompatible with the host system's PAM
+  # configuration on non-NixOS distributions.
+  nologinPackage = pkgs.runCommand "nologin" {
+    meta.mainProgram = "nologin";
+    passthru.shellPath = "/bin/nologin";
+  } ''
+    mkdir -p $out/bin
+    ln -s ${pkgs.shadow.out}/bin/nologin $out/bin/nologin
+  '';
+
   systemShells =
     let
       shells = mapAttrsToList (_: u: u.shell) cfg.users;
@@ -833,7 +846,6 @@ in
       cryptSchemeIdPatternGroup = "(${lib.concatStringsSep "|" pkgs.libxcrypt.enabledCryptSchemeIds})";
     in
     {
-
       users.defaultUserShell = lib.mkDefault pkgs.bashInteractive;
       users.users = {
         root = {
@@ -1001,6 +1013,16 @@ in
       # };
 
       assertions = [
+        {
+          assertion = !(lib.any (p: p == pkgs.shadow) config.environment.systemPackages);
+          message = ''
+            pkgs.shadow must not be in environment.systemPackages.
+            Its binaries (passwd, su, chsh, etc.) are linked against nix store
+            PAM libraries and are incompatible with the host system's PAM
+            configuration on non-NixOS distributions.
+            Use the host's native shadow utilities instead.
+          '';
+        }
         {
           assertion = !cfg.enforceIdUniqueness || (uidsAreUnique && gidsAreUnique);
           message = "UIDs and GIDs must be unique!";

--- a/testFlake/vm-tests.nix
+++ b/testFlake/vm-tests.nix
@@ -994,6 +994,13 @@ forEachUbuntuImage "example" {
         vm.succeed("test -x /run/wrappers/bin/mount")
         vm.succeed("test -x /run/wrappers/bin/umount")
 
+        # Shadow binaries must NOT be in system-manager PATH: they are linked
+        # against nix store PAM libraries and are incompatible with the host
+        # system's PAM configuration on non-NixOS distributions.
+        vm.fail("test -e /run/system-manager/sw/bin/passwd")
+        vm.fail("test -e /run/system-manager/sw/bin/su")
+        vm.fail("test -e /run/system-manager/sw/bin/chsh")
+
         # Build-time check output exists in toplevel
         vm.succeed("test -d ${toplevel}/checks")
 


### PR DESCRIPTION
Previously, the shadow binaries would be available in system-manager path but without the correct setuid permissions, which could lead to security issues and functionality problems.

This change ensures that the shadow binaries are not deployed in system-manager path.