### PR TITLE
fix: apply package overlay explicitly to fix nixpkgs.follows

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -30,13 +30,20 @@
         "aarch64-darwin"
         "x86_64-linux"
       ];
+      pkgsFor = nixpkgs.lib.genAttrs systems (
+        system:
+        import nixpkgs {
+          inherit system;
+          overlays = [ packageOverlay ];
+        }
+      );
       eachSystem =
         f:
         nixpkgs.lib.genAttrs systems (
           system:
           f {
             inherit system;
-            pkgs = nixpkgs.legacyPackages.${system};
+            pkgs = pkgsFor.${system};
           }
         );
       packageOverlay = final: _prev: rec {
@@ -63,8 +70,6 @@
       docs = eachSystem ({ pkgs, ... }: import ./docs/options.nix { inherit pkgs; });
 
       overlays.default = packageOverlay;
-      # Overlay packages onto internal nixpkgs
-      nixpkgs.overlays = [ packageOverlay ];
 
       # Only useful for quick tests
       systemConfigs.default = self.lib.makeSystemConfig {

--- a/nix/modules/upstream/nixpkgs/users-groups.nix
+++ b/nix/modules/upstream/nixpkgs/users-groups.nix
@@ -661,13 +661,16 @@ let
   # binaries (passwd, su, chsh, etc.) are linked against nix store PAM
   # libraries and are incompatible with the host system's PAM
   # configuration on non-NixOS distributions.
-  nologinPackage = pkgs.runCommand "nologin" {
-    meta.mainProgram = "nologin";
-    passthru.shellPath = "/bin/nologin";
-  } ''
-    mkdir -p $out/bin
-    ln -s ${pkgs.shadow.out}/bin/nologin $out/bin/nologin
-  '';
+  nologinPackage =
+    pkgs.runCommand "nologin"
+      {
+        meta.mainProgram = "nologin";
+        passthru.shellPath = "/bin/nologin";
+      }
+      ''
+        mkdir -p $out/bin
+        ln -s ${pkgs.shadow.out}/bin/nologin $out/bin/nologin
+      '';
 
   systemShells =
     let


### PR DESCRIPTION
The packageOverlay was not being applied to pkgs because nixpkgs.overlays as a flake output attribute has no effect on nixpkgs.legacyPackages. Use import nixpkgs with overlays instead, memoized via a pkgsFor attrset so each system's package set is created once and reused across all eachSystem calls.

Fixes #405