### PR TITLE
feat: add support for dhparams generation options

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -5,6 +5,7 @@
 }:
 {
   imports = [
+    ./dhparams.nix
     ./firewall.nix
     ./nginx.nix
     ./nix.nix
@@ -20,6 +21,7 @@
       "/misc/meta.nix"
       "/misc/ids.nix"
       "/security/acme/"
+      "/security/dhparams.nix"
       "/security/wrappers/"
       "/services/web-servers/nginx/"
       # nix settings

--- a/nix/modules/upstream/nixpkgs/dhparams.nix
+++ b/nix/modules/upstream/nixpkgs/dhparams.nix
@@ -1,0 +1,17 @@
+{ config, lib, ... }:
+let
+  cfg = config.security.dhparams;
+in
+{
+  config = lib.mkIf (cfg.enable && cfg.stateful) {
+    systemd.services = {
+      dhparams-init.wantedBy = lib.mkForce [ "system-manager.target" ];
+    }
+    // lib.mapAttrs' (
+      name: _:
+      lib.nameValuePair "dhparams-gen-${name}" {
+        wantedBy = lib.mkForce [ "system-manager.target" ];
+      }
+    ) cfg.params;
+  };
+}

--- a/testFlake/container-tests.nix
+++ b/testFlake/container-tests.nix
@@ -277,6 +277,43 @@ in
         '';
     };
 
+  container-nginx-dhparams = makeContainerTestFor "nginx-dhparams" {
+    modules = [
+      (
+        { ... }:
+        {
+          environment.etc."nix/nix.conf".replaceExisting = true;
+
+          services.nginx = {
+            enable = true;
+            sslDhparam = true;
+            virtualHosts."localhost" = {
+              root = "/var/www";
+              locations."/".extraConfig = ''
+                return 200 "ok";
+              '';
+            };
+          };
+        }
+      )
+    ];
+    testScriptFunction =
+      { toplevel, hostPkgs, ... }:
+      ''
+        start_all()
+
+        machine.wait_for_unit("multi-user.target")
+
+        activation_logs = machine.activate()
+        for line in activation_logs.split("\n"):
+            assert not "ERROR" in line, line
+        machine.wait_for_unit("system-manager.target")
+
+        with subtest("Verify nginx is running"):
+            assert machine.service("nginx").is_running, "nginx should be running"
+      '';
+  };
+
   container-systemd-packages = makeContainerTestFor "systemd-packages" {
     modules = [
       (

--- a/testFlake/flake.lock
+++ b/testFlake/flake.lock
@@ -83,11 +83,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1772773019,
-        "narHash": "sha256-E1bxHxNKfDoQUuvriG71+f+s/NT0qWkImXsYZNFFfCs=",
+        "lastModified": 1773389992,
+        "narHash": "sha256-wvfdLLWJ2I9oEpDd9PfMA8osfIZicoQ5MT1jIwNs9Tk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "aca4d95fce4914b3892661bcb80b8087293536c6",
+        "rev": "c06b4ae3d6599a672a6210b7021d699c351eebda",
         "type": "github"
       },
       "original": {
@@ -143,11 +143,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1772944399,
-        "narHash": "sha256-xTzsSd3r5HBeufSZ3fszAn0ldfKctvsYG7tT2YJg5gY=",
+        "lastModified": 1773096132,
+        "narHash": "sha256-M3zEnq9OElB7zqc+mjgPlByPm1O5t2fbUrH3t/Hm5Ag=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "c8e69670b316d6788e435a3aa0bda74eb1b82cc0",
+        "rev": "d1ff3b1034d5bab5d7d8086a7803c5a5968cd784",
         "type": "github"
       },
       "original": {
@@ -158,6 +158,7 @@
     },
     "system-manager": {
       "inputs": {
+        "flake-compat": "flake-compat",
         "nixpkgs": "nixpkgs",
         "userborn": "userborn"
       },
@@ -188,7 +189,10 @@
     },
     "userborn": {
       "inputs": {
-        "flake-compat": "flake-compat",
+        "flake-compat": [
+          "system-manager",
+          "flake-compat"
+        ],
         "flake-parts": "flake-parts",
         "nixpkgs": [
           "system-manager",


### PR DESCRIPTION
dhparams generation has been added as a dependency of the nixos nginx module. We add here support for generating dhparams files using the nixos module and a test to verify that nginx starts correctly when dhparams generation is enabled.