### PR TITLE
feat: add support specialArgs to makeSystemConfig

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -23,6 +23,7 @@ let
         modules,
         overlays ? [ ],
         extraSpecialArgs ? { },
+        specialArgs ? { },
       }:
       let
         # Module that sets additional module arguments
@@ -89,6 +90,7 @@ let
             specialArgs = {
               nixosModulesPath = "${nixos}/modules";
             }
+            // specialArgs
             // extraSpecialArgs;
             modules = [
               extraArgsModule
@@ -96,6 +98,19 @@ let
               {
                 _file = "${self.printAttrPos (builtins.unsafeGetAttrPos "a" { a = null; })}: inline module";
                 build = { inherit toplevel; };
+              }
+              {
+                config = {
+                  assertions = [
+                    {
+                      assertion = !((extraSpecialArgs != { }) && (specialArgs != { }));
+                      message = "extraSpecialArgs cannot be used together with specialArgs, please use specialArgs only instead";
+                    }
+                  ];
+                  warnings =
+                    lib.optional (extraSpecialArgs != { })
+                      "extraSpecialArgs is deprecated and will be removed in the next release, please use specialArgs instead";
+                };
               }
             ]
             ++ modules;


### PR DESCRIPTION
To have a similar interface to `nixpkgs.lib.nixosSystem`, we add a new argument specialArgs to makeSystemConfig, which is passed to the evalModules.

We also deprecate extraSpecialArgs as it is redundant with specialArgs.