### PR TITLE
feat: implement X-RestartIfChanged=false in service activation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,6 +209,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "freedesktop_entry_parser"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b368437186ec63ceb50d0832ee1ebcb5878037fe16ead1c68081d4aee0d140a"
+dependencies = [
+ "indexmap",
+ "nom",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -229,12 +239,6 @@ checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
  "foldhash",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
 name = "heck"
@@ -265,12 +269,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown",
  "serde",
  "serde_core",
 ]
@@ -369,6 +373,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -612,6 +625,7 @@ dependencies = [
  "clap",
  "dbus",
  "env_logger",
+ "freedesktop_entry_parser",
  "im",
  "itertools",
  "log",
@@ -733,7 +747,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags",
- "hashbrown 0.15.5",
+ "hashbrown",
  "indexmap",
  "semver",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ anyhow = "1.0.68"
 clap = { version = "4.1.4", features = ["derive"] }
 dbus = "0.9.7"
 env_logger = "0.11.0"
+freedesktop_entry_parser = "2.0.1"
 im = { version = "15.1.0", features = ["serde"] }
 itertools = "0.14.0"
 log = "0.4.17"

--- a/crates/system-manager-engine/Cargo.toml
+++ b/crates/system-manager-engine/Cargo.toml
@@ -19,6 +19,7 @@ anyhow.workspace = true
 clap.workspace = true
 dbus.workspace = true
 env_logger.workspace = true
+freedesktop_entry_parser.workspace = true
 im.workspace = true
 itertools.workspace = true
 log.workspace = true

--- a/crates/system-manager-engine/src/activate/services.rs
+++ b/crates/system-manager-engine/src/activate/services.rs
@@ -22,10 +22,11 @@ pub struct ServiceConfig {
 
 pub type Services = HashMap<String, ServiceConfig>;
 
-fn unit_has_directive(store_path: &StorePath, directive: &str) -> bool {
-    fs::read_to_string(&store_path.store_path)
-        .map(|content| content.contains(directive))
-        .unwrap_or(false)
+fn unit_directive(store_path: &StorePath, section: &str, key: &str) -> Option<String> {
+    let entry = freedesktop_entry_parser::parse_entry(&store_path.store_path)
+        .inspect_err(|e| log::debug!("unable to parse unit file {:?}: {e}", store_path.store_path))
+        .ok()?;
+    entry.section(section)?.attr(key).last().cloned()
 }
 
 fn print_services(services: &Services) -> String {
@@ -144,7 +145,8 @@ fn get_services_to_reload(services: Services, old_services: Services) -> Service
                 return false;
             }
             if let Some(ref path) = service.store_path {
-                if unit_has_directive(path, "X-RestartIfChanged=false") {
+                if unit_directive(path, "Service", "X-RestartIfChanged").as_deref() == Some("false")
+                {
                     log::info!("Skipping restart of {name}: X-RestartIfChanged=false");
                     return false;
                 }

--- a/crates/system-manager-engine/src/activate/services.rs
+++ b/crates/system-manager-engine/src/activate/services.rs
@@ -22,6 +22,12 @@ pub struct ServiceConfig {
 
 pub type Services = HashMap<String, ServiceConfig>;
 
+fn unit_has_directive(store_path: &StorePath, directive: &str) -> bool {
+    fs::read_to_string(&store_path.store_path)
+        .map(|content| content.contains(directive))
+        .unwrap_or(false)
+}
+
 fn print_services(services: &Services) -> String {
     let out = itertools::intersperse(
         services.iter().map(|(name, entry)| {
@@ -134,7 +140,16 @@ fn get_services_to_reload(services: Services, old_services: Services) -> Service
             return false;
         }
         if let Some(old_service) = old_services.get(name) {
-            service.store_path != old_service.store_path
+            if service.store_path == old_service.store_path {
+                return false;
+            }
+            if let Some(ref path) = service.store_path {
+                if unit_has_directive(path, "X-RestartIfChanged=false") {
+                    log::info!("Skipping restart of {name}: X-RestartIfChanged=false");
+                    return false;
+                }
+            }
+            true
         } else {
             // Since we run this on the intersection, this should never happen
             panic!("Something went terribly wrong!");

--- a/testFlake/container-tests/restart-if-changed.nix
+++ b/testFlake/container-tests/restart-if-changed.nix
@@ -1,0 +1,75 @@
+{
+  forEachDistro,
+  system-manager,
+  system,
+  ...
+}:
+
+let
+  configV2 = system-manager.lib.makeSystemConfig {
+    modules = [
+      {
+        nixpkgs.hostPlatform = system;
+
+        systemd.services.long-running-task = {
+          description = "Long Running Task";
+          wantedBy = [ "system-manager.target" ];
+          restartIfChanged = false;
+          serviceConfig.Type = "simple";
+          serviceConfig.Environment = "FOO=v2";
+          script = ''
+            sleep infinity
+          '';
+        };
+      }
+    ];
+  };
+in
+
+forEachDistro "restart-if-changed" {
+  modules = [
+    {
+      systemd.services.long-running-task = {
+        description = "Long Running Task";
+        wantedBy = [ "system-manager.target" ];
+        restartIfChanged = false;
+        serviceConfig.Type = "simple";
+        serviceConfig.Environment = "FOO=v1";
+        script = ''
+          sleep infinity
+        '';
+      };
+    }
+  ];
+  extraPathsToRegister = [ configV2 ];
+  testScriptFunction =
+    { toplevel, hostPkgs, ... }:
+    ''
+      start_all()
+
+      machine.wait_for_unit("multi-user.target")
+
+      with subtest("activate configV1 and verify service is running"):
+          activation_logs = machine.activate()
+          machine.wait_for_unit("system-manager.target")
+          result = machine.succeed("systemctl is-active long-running-task.service").strip()
+          assert result == "active", f"Expected active, got {result}"
+
+      with subtest("record initial PID"):
+          pid_before = machine.succeed("systemctl show -p MainPID --value long-running-task.service").strip()
+          assert pid_before != "0", "Service should have a non-zero PID"
+
+      with subtest("activate configV2 with X-RestartIfChanged=false"):
+          activation_logs = machine.activate(profile="${configV2}")
+          machine.wait_for_unit("system-manager.target")
+
+      with subtest("service was not restarted (same PID)"):
+          pid_after = machine.succeed("systemctl show -p MainPID --value long-running-task.service").strip()
+          assert pid_after == pid_before, \
+              f"Service was restarted: PID changed from {pid_before} to {pid_after}"
+
+      with subtest("activation logs show skip message"):
+          assert "Skipping restart" in activation_logs and "long-running-task" in activation_logs, \
+              f"Expected skip message in logs, got: {activation_logs}"
+    '';
+}


### PR DESCRIPTION
Prevents the engine from restarting services like the auto-upgrade service mid-execution when their unit files change.

required for #436