### PR TITLE
Etc activation: return old state if list_static_entries fails

### DIFF
--- a/crates/system-manager-engine/src/activate/etc_files.rs
+++ b/crates/system-manager-engine/src/activate/etc_files.rs
@@ -107,7 +107,7 @@ pub fn activate(
         Ok(e) => e,
         Err(e) => {
             return Err(ActivationError::WithPartialResult {
-                result: new_state.clone(),
+                result: old_state,
                 source: e,
             })
         }


### PR DESCRIPTION
list_static_entries is not modifying any file on the disk. If the operation fails, we should return the old etc files state and certainly not a empty state!!!! (my bad, this one's on me)

I did not manage to trigger this bug (you need a failing ls for that), but if it does manifest, it'd mean users would lose their system-manager state and lose their backup file state.