### PR TITLE
sshd: test dpkg reconfigure behaviour

### DIFF
--- a/testFlake/container-tests/ssh.nix
+++ b/testFlake/container-tests/ssh.nix
@@ -91,6 +91,14 @@ forEachDistro "ssh" {
           machine.succeed('ssh -i /etc/privatekey -o "StrictHostKeyChecking no" root@localhost echo ok')
           machine.succeed('echo "ls /" | sftp -i /etc/privatekey root@localhost')
 
+      with subtest("dpkg update do not remove system-managed owned files"):
+          sshd_sum_before_dpkg = sshd_config.sha256sum
+          machine.succeed("dpkg-reconfigure openssh-server --frontend=noninteractive")
+          sshd_config_new = machine.file("/etc/ssh/sshd_config")
+          assert sshd_config_new.exists, "/etc/ssh/sshd_config should exist"
+          assert sshd_config_new.sha256sum == sshd_sum_before_dpkg, \
+            "it seems like dpkg overwote /etc/ssh/sshd_config"
+
       with subtest("deactivation removes known hosts file"):
           machine.succeed("${toplevel}/bin/deactivate")
           machine.fail("test -f /etc/ssh/ssh_known_hosts")


### PR DESCRIPTION
We're using the openssh-server-provided binary, but we're disabling the systemd units and we're overriding its config.

I was expecting the dpkg install/reconfigure process to override our setup, but turns out it's not! Great news!

When running interactively, dpkg will prompt the user with the scary curse message asking the user whether or not they want to override their custom configuration pointing to the nix store. The default selection is to "no".

When running non-interactively, dpkg won't override any system-manager configuration. Adding a test ensuring that.

<img width="1274" height="1363" alt="image" src="https://github.com/user-attachments/assets/20bf6237-8142-4517-aaf7-714dd72eceeb" />
