### PR TITLE
fix: remove trailing slash in profile's PATH entry

### DIFF
--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -48,7 +48,7 @@
 
         etc = {
           "profile.d/system-manager-path.sh".source = pkgs.writeText "system-manager-path.sh" ''
-            export PATH=${pathDir}/bin/:''${PATH}
+            export PATH=${pathDir}/bin:''${PATH}
             ${config.environment.extraInit}
           '';
 


### PR DESCRIPTION
system-manager currently generates `system-manager-path.sh` in `/etc/profile.d`, containing the path `/run/system-manager/sw/bin/`. That trailing slash is redundant in PATH entries, as the shell itself will traverse the directory and construct the full path. Some shells (like zsh) will add another slash to PATH entries, which will expand paths to `/run/system-manager/sw/bin//COMMAND` when running any command installed to system-manager.