### PR TITLE
Add Debian support

### DIFF
--- a/.github/workflows/update-images.yml
+++ b/.github/workflows/update-images.yml
@@ -1,0 +1,28 @@
+name: update-images
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 5 * * 1" # runs weekly every Monday at 05:00 UTC
+
+jobs:
+  bump-images:
+    runs-on: "ubuntu-latest"
+    steps:
+      - name: "Checkout the repo"
+        uses: "actions/checkout@v6"
+      - name: "Install the Nix package manager"
+        uses: "cachix/install-nix-action@master"
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: "Refresh container test cloud image pins"
+        run: tools/update-images.py
+      - name: "Create Pull Request"
+        uses: "peter-evans/create-pull-request@v8"
+        with:
+          branch: "auto_update_images"
+          title: "Bump container test cloud image pins"
+          body: |
+            Automatically refreshed the cloud image URLs and sha256 hashes in
+            `lib/container-test-driver/images.json` by running
+            `tools/update-images.py`.
+          commit-message: "chore(container-tests): bump cloud image pins"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,21 +46,56 @@ Before creating a new issue, please [search existing issues](https://github.com/
 
 ## Adding New Distributions
 
-System Manager officially supports Ubuntu and NixOS. To add support for another distribution:
+System Manager officially supports Ubuntu, Debian, and NixOS.
+Promoting a new distribution to officially-supported status means it is exercised by CI on every PR and a regression in it blocks the build.
 
-1. Initialize a new flake with distribution checks disabled:
-   ```sh
-   nix run 'github:numtide/system-manager' -- init --flake --allow-any-distro
-   ```
+### Trying a distribution informally
 
-2. Switch to the new configuration:
-   ```sh
-   nix run 'github:numtide/system-manager' -- switch --flake '.'
-   ```
+If you just want to run System Manager on an untested distribution without contributing it back, initialize a flake and disable the OS check by setting `system-manager.allowAnyDistro = true` in your configuration module:
 
-3. Debug any errors that occur. Refer to the FAQ, GitHub issues, or open a discussion for help.
+```nix
+{
+  config.system-manager.allowAnyDistro = true;
+}
+```
 
-4. Once stable, the distribution can be added to the `supportedIds` list in the [system-manager module](./nix/modules/default.nix).
+Then iterate with `nix run 'github:numtide/system-manager' -- switch --flake '.'` and debug any errors using the FAQ, GitHub issues, or a discussion.
+Once the distribution is stable for your use case, consider upstreaming it via the steps below.
+
+### Adding official support
+
+Adding a distribution touches four areas: the OS allow-list, the container test driver, the VM test driver, and the documentation.
+
+**1. Add the distribution ID to the OS allow-list.**
+Edit `nix/modules/default.nix` and append the `/etc/os-release` `ID` value to the `supportedIds` list inside the `osVersion` pre-activation assertion.
+The check is bypassed when users set `system-manager.allowAnyDistro = true`, but the allow-list is what controls the default.
+
+**2. Add a container test entry.**
+Container tests live under `testFlake/container-tests/` and are parameterized over every distribution declared in `lib/container-test-driver/distros.nix`.
+Adding a new entry there causes all existing tests to automatically generate a `container-<distro>-*` variant via `forEachDistro`.
+
+The entry must supply `systems`, a `rootfs` derivation built by `lib.container-test-driver.make-rootfs.buildRootfs`, and a `maskableService` (a systemd unit that test scripts may mask, typically `unattended-upgrades.service` or equivalent).
+
+`buildRootfs` accepts two upstream image formats via `cloudImgFormat`.
+The default `"tar"` consumes a flat root tarball such as Ubuntu's `*-server-cloudimg-amd64-root.tar.xz` and is the simplest path.
+The `"qcow2"` branch extracts the rootfs from a cloud disk image using `guestfish tar-out`; this pulls in `libguestfs-with-appliance`, which restricts the entry to `x86_64-linux` because the appliance subpackage is not built for aarch64 in nixpkgs.
+Pin a specific dated build directory upstream rather than `latest/` and obtain the SHA256 with `nix-prefetch-url`.
+
+Reuse the existing `excludePatterns` (which strip container-incompatible systemd units) and `extraDirs` (per-package-manager directories like `var/lib/apt/lists/partial`) as a starting point and trim or extend them based on the first build.
+
+**3. Add a VM test entry.**
+VM tests live under `testFlake/vm-tests/` and iterate over distributions exposed by `nix-vm-test`.
+Edit the `distros` attrset in `testFlake/vm-tests/default.nix` to add a key matching the `nix-vm-test` distribution name (`ubuntu`, `debian`, `fedora`, `rocky`).
+Each entry takes a `filter` predicate that selects which versions to exercise — use it to skip versions you do not want in the matrix.
+If `nix-vm-test` does not yet support the distribution, support must be added there first.
+
+**4. Run the test matrix and triage failures.**
+Build the new check attributes via `nix build .#checks.x86_64-linux.container-<distro>-*` and `vm-<distro>-*-*` and triage any failures.
+Prefer fixing tests to be distribution-agnostic over skipping them.
+
+**5. Update documentation.**
+The user-facing platform statement lives in `docs/site/reference/supported-platforms.md`, with secondary mentions in `README.md`, `docs/site/how-to/install.md`, `docs/site/tutorials/getting-started.md`, and `docs/site/how-to/test-configuration.md`.
+Mention the new distribution alongside the existing supported ones.
 
 ## Creating an Ad-Hoc Release
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,10 +76,13 @@ Adding a new entry there causes all existing tests to automatically generate a `
 
 The entry must supply `systems`, a `rootfs` derivation built by `lib.container-test-driver.make-rootfs.buildRootfs`, and a `maskableService` (a systemd unit that test scripts may mask, typically `unattended-upgrades.service` or equivalent).
 
-`buildRootfs` accepts two upstream image formats via `cloudImgFormat`.
-The default `"tar"` consumes a flat root tarball such as Ubuntu's `*-server-cloudimg-amd64-root.tar.xz` and is the simplest path.
-The `"qcow2"` branch extracts the rootfs from a cloud disk image using `guestfish tar-out`; this pulls in `libguestfs-with-appliance`, which restricts the entry to `x86_64-linux` because the appliance subpackage is not built for aarch64 in nixpkgs.
-Pin a specific dated build directory upstream rather than `latest/` and obtain the SHA256 with `nix-prefetch-url`.
+`buildRootfs` accepts three upstream image formats via `cloudImgFormat`, and the right choice depends on what the distribution publishes:
+
+- `"tar"` (default) consumes a flat rootfs tarball such as Ubuntu's `*-server-cloudimg-amd64-root.tar.xz`. This is the simplest path, has no architecture restrictions, and should be preferred whenever the distribution ships a rootfs tarball.
+- `"disk-tarball"` consumes a `.tar.xz` that wraps a raw disk image, such as Debian's `*-genericcloud-*.tar.xz`. It unpacks the outer tarball, locates the root partition with `sfdisk -J` + `jq`, extracts it with `dd`, and dumps the ext4 filesystem into `$out` via `debugfs -R "rdump / $out"`. All required tools (`util-linux`, `e2fsprogs`, `jq`) are cross-architecture in nixpkgs, so this works on both `x86_64-linux` and `aarch64-linux`. `excludePatterns` are applied as a post-extraction prune pass rather than as tar `--exclude` flags. Note: this currently assumes the root filesystem is ext4; a btrfs-backed rootfs (such as Fedora Workstation) would need a `btrfs restore`-based variant added alongside.
+- `"qcow2"` extracts the rootfs from a qcow2 cloud disk image using `guestfish tar-out`. It pulls in `libguestfs-with-appliance`, whose `libguestfs-appliance` subpackage is marked `meta.platforms = [ "i686-linux" "x86_64-linux" ]` in nixpkgs, so entries using this format must restrict `systems` to `x86_64-linux`. Use only as a last resort, when the distribution publishes neither a rootfs tarball nor a disk-in-tarball variant.
+
+Pin a specific dated build directory upstream rather than `latest/` and obtain the SHA256 with `nix-prefetch-url`. URL and hash go in `lib/container-test-driver/images.json`; `distros.nix` reads them automatically.
 
 Reuse the existing `excludePatterns` (which strip container-incompatible systemd units) and `extraDirs` (per-package-manager directories like `var/lib/apt/lists/partial`) as a starting point and trim or extend them based on the first build.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ Before creating a new issue, please [search existing issues](https://github.com/
 
 ## Adding New Distributions
 
-System Manager officially supports Ubuntu, Debian, and NixOS.
+System Manager officially supports Ubuntu and Debian.
 Promoting a new distribution to officially-supported status means it is exercised by CI on every PR and a regression in it blocks the build.
 
 ### Trying a distribution informally

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ You can find the [full documentation here](https://system-manager.net/main/).
 
 ## Quick Example to Get Started
 
-We will assume you're using a non-NixOS distribution (such as Ubuntu) and you have Nix already installed, with flakes enabled.
+We will assume you're using a non-NixOS distribution (such as Ubuntu or Debian) and you have Nix already installed, with flakes enabled.
 
 System Manager has an "init" subcommand that can build a set of starting files for you. By default, it places the files in `~/.config/system-manager`. You can run this init subcommand by typing:
 
@@ -214,7 +214,7 @@ Then re-run System Manager and your changes will take effect; now you should hav
 
 ## Supported Systems
 
-System Manager is currently only supported on NixOS and Ubuntu. However, it can be used on other distributions by enabling the following:
+System Manager is currently supported on NixOS, Ubuntu, and Debian. However, it can be used on other distributions by enabling the following:
 
 ```nix
 {

--- a/docs/site/how-to/install.md
+++ b/docs/site/how-to/install.md
@@ -96,45 +96,6 @@ system-manager switch --flake . --sudo
 !!! Tip
     System Manager is still in early development. Installing locally will not immediately pick up new changes. If you decide to install locally, periodically check the GitHub repo for changes and upgrade using `nix profile upgrade`.
 
-# Installing on NixOS
-
-If you're on NixOS and want to install the `system-manager` CLI as a system package, add it to your NixOS configuration:
-
-```nix
-# flake.nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
-    system-manager = {
-      url = "github:numtide/system-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
-  };
-
-  outputs = { self, nixpkgs, system-manager, ... }:
-    let
-      system = "x86_64-linux";
-    in {
-      nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
-        inherit system;
-        modules = [
-          ({ config, ... }: {
-            environment.systemPackages = [
-              system-manager.packages.${system}.system-manager
-            ];
-          })
-        ];
-      };
-    };
-}
-```
-
-Then rebuild:
-
-```sh
-sudo nixos-rebuild switch --flake .#myhost
-```
-
 # Version Compatibility
 
 Occasionally, the nixpkgs version may be incompatible with the `main` branch of System Manager. If you encounter build errors, you may need to pin to a specific commit.

--- a/docs/site/how-to/install.md
+++ b/docs/site/how-to/install.md
@@ -4,7 +4,7 @@
 
 To use System Manager, you need:
 
-* **A Linux machine.** We've tested System Manager with Ubuntu both as standalone and under Windows Subsystem for Linux (WSL).
+* **A Linux machine.** We've tested System Manager with Ubuntu (both as standalone and under Windows Subsystem for Linux) and Debian 13 (trixie).
 * **At least 12GB Disk Space.** However, we recommend at least 16GB, as you will be very tight for space with under 16GB. (This is primarily due to Nix; if you're using System Manager to configure, for example, small servers on the Cloud, 8GB simply won't be enough.)
 * **Nix installed system-wide** with flakes enabled. (System Manager doesn't work with a per-user installation of Nix)
 

--- a/docs/site/how-to/test-configuration.md
+++ b/docs/site/how-to/test-configuration.md
@@ -166,7 +166,7 @@ Test "Verify application files" (0.3s)
 ```python
 start_all()
 
-# Wait for Ubuntu systemd to be ready
+# Wait for the distro's systemd to be ready
 machine.wait_for_unit("multi-user.target")
 
 # Activate system-manager configuration (displays full activation output)
@@ -196,7 +196,7 @@ with subtest("Verify service is responding"):
 
 The test framework:
 
-1. Builds an Ubuntu 24.04 container image with the nix-installer binary included
+1. Builds a container image (Ubuntu 22.04, Ubuntu 24.04, or Debian 13) with the nix-installer binary included
 2. Starts the container using systemd-nspawn within the Nix build sandbox
 3. Installs Nix via nix-installer at container startup (multi-user mode with daemon)
 4. Copies your system-manager profile closure into the container via `nix copy`

--- a/docs/site/reference/supported-platforms.md
+++ b/docs/site/reference/supported-platforms.md
@@ -8,7 +8,6 @@ System Manager runs on Linux systems that use systemd for service management.
 |----------|--------|-------|
 | Ubuntu 22.04+ | Tested | Primary development platform |
 | Ubuntu on WSL2 | Tested | Windows Subsystem for Linux |
-| NixOS | Tested | Works alongside existing NixOS configuration |
 | Debian 13 (trixie) | Tested | Container and VM tests |
 | Fedora | Community | Should work; uses systemd |
 | Arch Linux | Community | Should work; uses systemd |

--- a/docs/site/reference/supported-platforms.md
+++ b/docs/site/reference/supported-platforms.md
@@ -9,7 +9,7 @@ System Manager runs on Linux systems that use systemd for service management.
 | Ubuntu 22.04+ | Tested | Primary development platform |
 | Ubuntu on WSL2 | Tested | Windows Subsystem for Linux |
 | NixOS | Tested | Works alongside existing NixOS configuration |
-| Debian | Community | Should work; similar to Ubuntu |
+| Debian 13 (trixie) | Tested | Container and VM tests |
 | Fedora | Community | Should work; uses systemd |
 | Arch Linux | Community | Should work; uses systemd |
 
@@ -29,7 +29,7 @@ System Manager runs on Linux systems that use systemd for service management.
 ## Platform detection
 
 System Manager checks the platform at activation time using a pre-activation assertion that reads `/etc/os-release`.
-By default, it only allows activation on Ubuntu and NixOS.
+By default, it only allows activation on Ubuntu, Debian, and NixOS.
 
 ### Enabling other distributions
 
@@ -44,7 +44,7 @@ To allow System Manager to run on untested distributions, set the `system-manage
 ```
 
 This disables the OS check entirely.
-There is no option to selectively allow specific distributions; the check is either on (default, allowing only Ubuntu and NixOS) or off.
+There is no option to selectively allow specific distributions; the check is either on (default, allowing only Ubuntu, Debian, and NixOS) or off.
 
 ## Limitations
 

--- a/docs/site/tutorials/getting-started.md
+++ b/docs/site/tutorials/getting-started.md
@@ -2,7 +2,7 @@
 
 If you've heard of NixOS, you've probably heard that it lets you define your entire system in configuration files and then reproduce that system anywhere with a single command. System Manager brings that same declarative model to other Linux distributions*, with no reinstalling, no switching operating systems, and no special prerequisites beyond having Nix installed.
 
-*Presently, System Manager is only tested on Ubuntu, and is limited to only Linux distributions based on systemd.
+*Presently, System Manager is tested on Ubuntu and Debian, and is limited to only Linux distributions based on systemd.
 
 # Initializing Your System
 

--- a/lib/container-test-driver/distros.nix
+++ b/lib/container-test-driver/distros.nix
@@ -4,6 +4,16 @@
 }:
 let
   makeRootfs = import ./make-rootfs.nix { inherit pkgs system; };
+  images = builtins.fromJSON (builtins.readFile ./images.json);
+
+  fetchCloudImg =
+    distroName:
+    let
+      entry = images.${distroName}.${system} or (throw "Unsupported system for ${distroName}: ${system}");
+    in
+    builtins.fetchurl {
+      inherit (entry) url sha256;
+    };
 
   ubuntuExcludePatterns = [
     "etc/systemd/system/network-online.target.wants/*"
@@ -23,25 +33,11 @@ let
 in
 {
   ubuntu-22_04 = {
-    systems = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+    systems = builtins.attrNames images.ubuntu-22_04;
     rootfs = makeRootfs.buildRootfs {
       name = "ubuntu-22_04";
-      cloudImg =
-        if system == "x86_64-linux" then
-          builtins.fetchurl {
-            url = "https://cloud-images.ubuntu.com/releases/jammy/release-20260227/ubuntu-22.04-server-cloudimg-amd64-root.tar.xz";
-            sha256 = "05gw1sspv9d4m5yazc8105yc2vr3y9xkwnwilnzn774w9nivwib3";
-          }
-        else if system == "aarch64-linux" then
-          builtins.fetchurl {
-            url = "https://cloud-images.ubuntu.com/releases/jammy/release-20260227/ubuntu-22.04-server-cloudimg-arm64-root.tar.xz";
-            sha256 = "1aya4ainn5289bhczbx97dxv7ck8ng3kmz8yiicz8ynvyfg6mvrq";
-          }
-        else
-          throw "Unsupported system: ${system}";
+      cloudImg = fetchCloudImg "ubuntu-22_04";
+      cloudImgFormat = "tar";
       excludePatterns = ubuntuExcludePatterns;
       extraDirs = [ "var/lib/apt/lists/partial" ];
     };
@@ -49,25 +45,11 @@ in
   };
 
   ubuntu-24_04 = {
-    systems = [
-      "x86_64-linux"
-      "aarch64-linux"
-    ];
+    systems = builtins.attrNames images.ubuntu-24_04;
     rootfs = makeRootfs.buildRootfs {
       name = "ubuntu-24_04";
-      cloudImg =
-        if system == "x86_64-linux" then
-          builtins.fetchurl {
-            url = "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-amd64-root.tar.xz";
-            sha256 = "0y3d55f5qy7bxm3mfmnxzpmwp88d7iiszc57z5b9npc6xgwi28np";
-          }
-        else if system == "aarch64-linux" then
-          builtins.fetchurl {
-            url = "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-arm64-root.tar.xz";
-            sha256 = "1l4l0llfffspzgnmwhax0fcnjn8ih8n4azhfaghng2hh1xvr4a17";
-          }
-        else
-          throw "Unsupported system: ${system}";
+      cloudImg = fetchCloudImg "ubuntu-24_04";
+      cloudImgFormat = "tar";
       excludePatterns = ubuntuExcludePatterns;
       extraDirs = [ "var/lib/apt/lists/partial" ];
     };
@@ -75,9 +57,7 @@ in
   };
 
   debian-13 = {
-    # x86_64-linux only: the qcow2 extraction path uses libguestfs-with-appliance,
-    # whose appliance subpackage is not available on aarch64 in nixpkgs.
-    systems = [ "x86_64-linux" ];
+    systems = builtins.attrNames images.debian-13;
     rootfs = makeRootfs.buildRootfs {
       name = "debian-13";
       cloudImgFormat = "qcow2";

--- a/lib/container-test-driver/distros.nix
+++ b/lib/container-test-driver/distros.nix
@@ -73,4 +73,21 @@ in
     };
     maskableService = "unattended-upgrades.service";
   };
+
+  debian-13 = {
+    # x86_64-linux only: the qcow2 extraction path uses libguestfs-with-appliance,
+    # whose appliance subpackage is not available on aarch64 in nixpkgs.
+    systems = [ "x86_64-linux" ];
+    rootfs = makeRootfs.buildRootfs {
+      name = "debian-13";
+      cloudImgFormat = "qcow2";
+      cloudImg = builtins.fetchurl {
+        url = "https://cloud.debian.org/images/cloud/trixie/20260413-2447/debian-13-genericcloud-amd64-20260413-2447.qcow2";
+        sha256 = "0iclqh20da7mm1ijhks66iqy2dz1shpipia1zwpgxpya1c4gg182";
+      };
+      excludePatterns = ubuntuExcludePatterns;
+      extraDirs = [ "var/lib/apt/lists/partial" ];
+    };
+    maskableService = "unattended-upgrades.service";
+  };
 }

--- a/lib/container-test-driver/distros.nix
+++ b/lib/container-test-driver/distros.nix
@@ -60,11 +60,8 @@ in
     systems = builtins.attrNames images.debian-13;
     rootfs = makeRootfs.buildRootfs {
       name = "debian-13";
-      cloudImgFormat = "qcow2";
-      cloudImg = builtins.fetchurl {
-        url = "https://cloud.debian.org/images/cloud/trixie/20260413-2447/debian-13-genericcloud-amd64-20260413-2447.qcow2";
-        sha256 = "0iclqh20da7mm1ijhks66iqy2dz1shpipia1zwpgxpya1c4gg182";
-      };
+      cloudImgFormat = "disk-tarball";
+      cloudImg = fetchCloudImg "debian-13";
       excludePatterns = ubuntuExcludePatterns;
       extraDirs = [ "var/lib/apt/lists/partial" ];
     };

--- a/lib/container-test-driver/images.json
+++ b/lib/container-test-driver/images.json
@@ -1,0 +1,32 @@
+{
+  "debian-13": {
+    "aarch64-linux": {
+      "sha256": "02jhbgc97kapbdnk8ny6ql12g9xvi34jpirp5kxzgcz1b5wabwg4",
+      "url": "https://cloud.debian.org/images/cloud/trixie/20260413-2447/debian-13-genericcloud-arm64-20260413-2447.tar.xz"
+    },
+    "x86_64-linux": {
+      "sha256": "049a06pb4bqpmy6qp3jgzblrwim9i492153mcglm53jngh48r5p5",
+      "url": "https://cloud.debian.org/images/cloud/trixie/20260413-2447/debian-13-genericcloud-amd64-20260413-2447.tar.xz"
+    }
+  },
+  "ubuntu-22_04": {
+    "aarch64-linux": {
+      "sha256": "1aya4ainn5289bhczbx97dxv7ck8ng3kmz8yiicz8ynvyfg6mvrq",
+      "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260227/ubuntu-22.04-server-cloudimg-arm64-root.tar.xz"
+    },
+    "x86_64-linux": {
+      "sha256": "05gw1sspv9d4m5yazc8105yc2vr3y9xkwnwilnzn774w9nivwib3",
+      "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260227/ubuntu-22.04-server-cloudimg-amd64-root.tar.xz"
+    }
+  },
+  "ubuntu-24_04": {
+    "aarch64-linux": {
+      "sha256": "1l4l0llfffspzgnmwhax0fcnjn8ih8n4azhfaghng2hh1xvr4a17",
+      "url": "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-arm64-root.tar.xz"
+    },
+    "x86_64-linux": {
+      "sha256": "0y3d55f5qy7bxm3mfmnxzpmwp88d7iiszc57z5b9npc6xgwi28np",
+      "url": "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-amd64-root.tar.xz"
+    }
+  }
+}

--- a/lib/container-test-driver/images.json
+++ b/lib/container-test-driver/images.json
@@ -11,22 +11,22 @@
   },
   "ubuntu-22_04": {
     "aarch64-linux": {
-      "sha256": "1aya4ainn5289bhczbx97dxv7ck8ng3kmz8yiicz8ynvyfg6mvrq",
-      "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260227/ubuntu-22.04-server-cloudimg-arm64-root.tar.xz"
+      "sha256": "0fg2jv8wi5cqlw0sl07xi3jmyyk1056pzybfqgpxs3nx7crhajlf",
+      "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260320/ubuntu-22.04-server-cloudimg-arm64-root.tar.xz"
     },
     "x86_64-linux": {
-      "sha256": "05gw1sspv9d4m5yazc8105yc2vr3y9xkwnwilnzn774w9nivwib3",
-      "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260227/ubuntu-22.04-server-cloudimg-amd64-root.tar.xz"
+      "sha256": "1dafwd805bh4c243g7p16jixb52amh09p23ibx1lyj4k50d5yrad",
+      "url": "https://cloud-images.ubuntu.com/releases/jammy/release-20260320/ubuntu-22.04-server-cloudimg-amd64-root.tar.xz"
     }
   },
   "ubuntu-24_04": {
     "aarch64-linux": {
-      "sha256": "1l4l0llfffspzgnmwhax0fcnjn8ih8n4azhfaghng2hh1xvr4a17",
-      "url": "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-arm64-root.tar.xz"
+      "sha256": "07vjiwx0smm6hyahi8w9y54zyxbpczfaqh75ihvi4msmmhbwb0m6",
+      "url": "https://cloud-images.ubuntu.com/releases/noble/release-20260321/ubuntu-24.04-server-cloudimg-arm64-root.tar.xz"
     },
     "x86_64-linux": {
-      "sha256": "0y3d55f5qy7bxm3mfmnxzpmwp88d7iiszc57z5b9npc6xgwi28np",
-      "url": "https://cloud-images.ubuntu.com/releases/noble/release-20251026/ubuntu-24.04-server-cloudimg-amd64-root.tar.xz"
+      "sha256": "0xyp9pin8m6ys0gxk6spq83dgdfl3malbvps7v78hrp7sjg3rp0k",
+      "url": "https://cloud-images.ubuntu.com/releases/noble/release-20260321/ubuntu-24.04-server-cloudimg-amd64-root.tar.xz"
     }
   }
 }

--- a/lib/container-test-driver/make-rootfs.nix
+++ b/lib/container-test-driver/make-rootfs.nix
@@ -22,6 +22,9 @@ in
         map (p: "--exclude='${p}'") excludePatterns
       );
       mkdirCommands = builtins.concatStringsSep "\n    " (map (d: "mkdir -p $out/${d}") extraDirs);
+      excludePruneCommands = builtins.concatStringsSep "\n    " (
+        map (p: "rm -rf $out/${p}") excludePatterns
+      );
       extractCommand =
         if cloudImgFormat == "tar" then
           ''
@@ -38,12 +41,45 @@ in
                     ${excludeArgs} \
                     -C $out -x
           ''
+        else if cloudImgFormat == "disk-tarball" then
+          ''
+            set -euo pipefail
+
+            workdir=$(mktemp -d)
+            tar -C "$workdir" -xf ${cloudImg}
+            rawimg=$(ls "$workdir"/*.raw | head -n1)
+            if [ -z "$rawimg" ]; then
+              echo "disk-tarball: no *.raw file inside ${cloudImg}" >&2
+              exit 1
+            fi
+
+            # Pick the largest partition
+            read -r start size <<<"$(sfdisk -J "$rawimg" \
+              | jq -r '.partitiontable.partitions | max_by(.size) | "\(.start) \(.size)"')"
+            dd if="$rawimg" of="$workdir/root.ext4" \
+               bs=512 skip="$start" count="$size" status=none
+
+            debugfs -R "rdump / $out" "$workdir/root.ext4" >/dev/null 2>&1
+
+            # debugfs rdump has no --exclude, so apply excludePatterns via a
+            # post-extraction prune pass. Also strip /dev/* to match the tar
+            # path (which uses tar --exclude='dev/*').
+            rm -rf $out/dev/*
+            ${excludePruneCommands}
+
+            rm -rf "$workdir"
+          ''
         else
-          throw "buildRootfs: unsupported cloudImgFormat '${cloudImgFormat}' (expected 'tar' or 'qcow2')";
+          throw "buildRootfs: unsupported cloudImgFormat '${cloudImgFormat}' (expected 'tar', 'qcow2', or 'disk-tarball')";
       nativeBuildInputs = [
         pkgs.xz
       ]
-      ++ pkgs.lib.optionals (cloudImgFormat == "qcow2") [ pkgs.libguestfs-with-appliance ];
+      ++ pkgs.lib.optionals (cloudImgFormat == "qcow2") [ pkgs.libguestfs-with-appliance ]
+      ++ pkgs.lib.optionals (cloudImgFormat == "disk-tarball") [
+        pkgs.util-linux
+        pkgs.e2fsprogs
+        pkgs.jq
+      ];
     in
     pkgs.runCommand "rootfs-${name}"
       {

--- a/lib/container-test-driver/make-rootfs.nix
+++ b/lib/container-test-driver/make-rootfs.nix
@@ -10,6 +10,7 @@ in
     {
       name,
       cloudImg,
+      cloudImgFormat,
       excludePatterns ? [ ],
       extraDirs ? [ ],
       extraSetup ? "",
@@ -21,19 +22,38 @@ in
         map (p: "--exclude='${p}'") excludePatterns
       );
       mkdirCommands = builtins.concatStringsSep "\n    " (map (d: "mkdir -p $out/${d}") extraDirs);
+      extractCommand =
+        if cloudImgFormat == "tar" then
+          ''
+            tar --exclude='dev/*' \
+                ${excludeArgs} \
+                ${tarExtraFlags} \
+                ${tarCompression}xf ${cloudImg} -C $out
+          ''
+        else if cloudImgFormat == "qcow2" then
+          ''
+            LIBGUESTFS_BACKEND=direct \
+              guestfish --ro -a ${cloudImg} -i tar-out / - \
+              | tar --exclude='dev/*' \
+                    ${excludeArgs} \
+                    -C $out -x
+          ''
+        else
+          throw "buildRootfs: unsupported cloudImgFormat '${cloudImgFormat}' (expected 'tar' or 'qcow2')";
+      nativeBuildInputs = [
+        pkgs.xz
+      ]
+      ++ pkgs.lib.optionals (cloudImgFormat == "qcow2") [ pkgs.libguestfs-with-appliance ];
     in
     pkgs.runCommand "rootfs-${name}"
       {
-        nativeBuildInputs = [ pkgs.xz ];
+        inherit nativeBuildInputs;
       }
       ''
         mkdir -p $out
 
         # Extract cloud image, excluding container-incompatible services
-        tar --exclude='dev/*' \
-            ${excludeArgs} \
-            ${tarExtraFlags} \
-            ${tarCompression}xf ${cloudImg} -C $out
+        ${extractCommand}
 
         # Ensure build user can modify all extracted files
         chmod -R u+rwX $out

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -214,6 +214,7 @@
           supportedIds = [
             "nixos"
             "ubuntu"
+            "debian"
           ];
         in
         {

--- a/testFlake/flake.lock
+++ b/testFlake/flake.lock
@@ -131,6 +131,8 @@
       "locked": {
         "lastModified": 1776243694,
         "narHash": "sha256-bmPLrDLMb2QjGhWzDHvahyq4nuoSoYEMsgmo+qHiq1k=",
+        "lastModified": 1776165142,
+        "narHash": "sha256-bmPLrDLMb2QjGhWzDHvahyq4nuoSoYEMsgmo+qHiq1k=",
         "owner": "numtide",
         "repo": "nix-vm-test",
         "rev": "797184bcad6205f0360250298598de38cf781df0",

--- a/testFlake/flake.lock
+++ b/testFlake/flake.lock
@@ -129,13 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776243694,
-        "narHash": "sha256-bmPLrDLMb2QjGhWzDHvahyq4nuoSoYEMsgmo+qHiq1k=",
-        "lastModified": 1776165142,
-        "narHash": "sha256-bmPLrDLMb2QjGhWzDHvahyq4nuoSoYEMsgmo+qHiq1k=",
+        "lastModified": 1776849104,
+        "narHash": "sha256-pxBQj/PL2lGrnaCrchNeUAw1057Nn9G0XQzo8KUoxic=",
         "owner": "numtide",
         "repo": "nix-vm-test",
-        "rev": "797184bcad6205f0360250298598de38cf781df0",
+        "rev": "be5379d18ae1c4ad25d950d9a785008cb5998d69",
         "type": "github"
       },
       "original": {

--- a/testFlake/vm-tests/default.nix
+++ b/testFlake/vm-tests/default.nix
@@ -7,7 +7,18 @@
 }:
 
 let
-  forEachUbuntuImage =
+  distros = {
+    ubuntu = {
+      # Ubuntu 20.04 reaches end of life April 2025; drop support.
+      filter = v: v != "20_04";
+    };
+    debian = {
+      # Only Debian 13 (trixie)
+      filter = v: v == "13";
+    };
+  };
+
+  forEachImage =
     name:
     {
       modules,
@@ -16,47 +27,54 @@ let
       projectTest ? test: test.sandboxed,
     }:
     let
-      ubuntu = nix-vm-test.ubuntu;
-    in
-    lib.listToAttrs (
-      # Ubuntu 20.04 reaches end of life April 2025; drop support.
-      lib.flip map (lib.filter (v: v != "20_04") (lib.attrNames ubuntu.images)) (
-        imageVersion:
-        let
-          toplevel = (
-            system-manager.lib.makeSystemConfig {
-              modules = modules ++ [
-                (
-                  { lib, pkgs, ... }:
-                  {
-                    options.hostPkgs = lib.mkOption {
-                      type = lib.types.raw;
-                      readOnly = true;
-                    };
-                    config = {
-                      nixpkgs.hostPlatform = system;
-                      hostPkgs = pkgs;
-                    };
-                  }
-                )
-              ];
-            }
-          );
-          inherit (toplevel.config) hostPkgs;
-        in
-        lib.nameValuePair "vm-ubuntu-${imageVersion}-${name}" (
-          projectTest (
-            ubuntu.${imageVersion} {
-              testScript = testScriptFunction { inherit toplevel hostPkgs; };
-              extraPathsToRegister = extraPathsToRegister ++ [
-                toplevel
-              ];
-              sharedDirs = { };
+      mkToplevel = system-manager.lib.makeSystemConfig {
+        modules = modules ++ [
+          (
+            { lib, pkgs, ... }:
+            {
+              options.hostPkgs = lib.mkOption {
+                type = lib.types.raw;
+                readOnly = true;
+              };
+              config = {
+                nixpkgs.hostPlatform = system;
+                hostPkgs = pkgs;
+              };
             }
           )
-        )
-      )
-    );
+        ];
+      };
+      mkTestForDistro =
+        distroName: distroConfig:
+        let
+          distro = nix-vm-test.${distroName};
+          versions = lib.filter distroConfig.filter (lib.attrNames distro.images);
+        in
+        lib.listToAttrs (
+          map (
+            imageVersion:
+            let
+              toplevel = mkToplevel;
+              inherit (toplevel.config) hostPkgs;
+            in
+            lib.nameValuePair "vm-${distroName}-${imageVersion}-${name}" (
+              projectTest (
+                distro.${imageVersion} {
+                  testScript = testScriptFunction { inherit toplevel hostPkgs; };
+                  extraPathsToRegister = extraPathsToRegister ++ [
+                    toplevel
+                  ];
+                  sharedDirs = { };
+                }
+              )
+            )
+          ) versions
+        );
+    in
+    lib.foldlAttrs (
+      acc: distroName: distroConfig:
+      acc // mkTestForDistro distroName distroConfig
+    ) { } distros;
 
   newConfig = system-manager.lib.makeSystemConfig {
     modules = [
@@ -142,7 +160,7 @@ let
     file:
     import file {
       inherit
-        forEachUbuntuImage
+        forEachImage
         newConfig
         system-manager
         system

--- a/testFlake/vm-tests/example.nix
+++ b/testFlake/vm-tests/example.nix
@@ -1,11 +1,11 @@
 {
-  forEachUbuntuImage,
+  forEachImage,
   newConfig,
   system-manager,
   ...
 }:
 
-forEachUbuntuImage "example" {
+forEachImage "example" {
   modules = [
     ../../examples/example.nix
   ];

--- a/testFlake/vm-tests/prepopulate.nix
+++ b/testFlake/vm-tests/prepopulate.nix
@@ -1,11 +1,11 @@
 {
-  forEachUbuntuImage,
+  forEachImage,
   newConfig,
   system-manager,
   ...
 }:
 
-forEachUbuntuImage "prepopulate" {
+forEachImage "prepopulate" {
   modules = [
     ../../examples/example.nix
   ];

--- a/testFlake/vm-tests/security-wrappers.nix
+++ b/testFlake/vm-tests/security-wrappers.nix
@@ -2,12 +2,12 @@
 # This must run in a VM because setting SUID bits and file capabilities
 # requires privileges that the nix build sandbox seccomp filter blocks.
 {
-  forEachUbuntuImage,
+  forEachImage,
   system-manager,
   ...
 }:
 
-forEachUbuntuImage "security-wrappers" {
+forEachImage "security-wrappers" {
   modules = [
     (
       { pkgs, ... }:

--- a/testFlake/vm-tests/sudo-module.nix
+++ b/testFlake/vm-tests/sudo-module.nix
@@ -1,12 +1,12 @@
 # Test sudo module: sudoers generation, no Nix-built sudo in PATH/wrappers,
 # and host sudo works with the generated config.
 {
-  forEachUbuntuImage,
+  forEachImage,
   system-manager,
   ...
 }:
 
-forEachUbuntuImage "sudo-module" {
+forEachImage "sudo-module" {
   modules = [
     (
       { ... }:

--- a/testFlake/vm-tests/sudo.nix
+++ b/testFlake/vm-tests/sudo.nix
@@ -3,13 +3,13 @@
 # 1. Running system-manager as non-root without --sudo fails
 # 2. Running system-manager with --sudo succeeds
 {
-  forEachUbuntuImage,
+  forEachImage,
   system-manager,
   system,
   ...
 }:
 
-forEachUbuntuImage "sudo" {
+forEachImage "sudo" {
   modules = [
     ../../examples/example.nix
   ];

--- a/testFlake/vm-tests/target-host.nix
+++ b/testFlake/vm-tests/target-host.nix
@@ -2,13 +2,13 @@
 # This test runs the engine directly via SSH from the host (test driver) to the VM
 # It tests that the engine can be invoked remotely, which is the core of --target-host
 {
-  forEachUbuntuImage,
+  forEachImage,
   system-manager,
   system,
   ...
 }:
 
-forEachUbuntuImage "target-host" {
+forEachImage "target-host" {
   modules = [
     ../../examples/example.nix
   ];

--- a/tools/update-images.py
+++ b/tools/update-images.py
@@ -1,0 +1,140 @@
+#! /usr/bin/env nix-shell
+#! nix-shell -i python3 -p python3 python3Packages.beautifulsoup4 python3Packages.requests nix-prefetch
+
+import json
+import re
+import subprocess
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import requests
+from bs4 import BeautifulSoup
+
+IMAGES_JSON = (
+    Path(__file__).resolve().parent.parent
+    / "lib"
+    / "container-test-driver"
+    / "images.json"
+)
+
+# distro -> upstream index URL (must end with "/")
+UBUNTU_RELEASES = {
+    "ubuntu-22_04": "https://cloud-images.ubuntu.com/releases/jammy/",
+    "ubuntu-24_04": "https://cloud-images.ubuntu.com/releases/noble/",
+}
+
+DEBIAN_RELEASES = {
+    "debian-13": "https://cloud.debian.org/images/cloud/trixie/",
+}
+
+
+def nix_hash(url: str) -> str:
+    print(f"[+] nix-prefetch-url {url}", file=sys.stderr)
+    result = subprocess.run(
+        ["nix-prefetch-url", "--type", "sha256", url],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return result.stdout.strip()
+
+
+def latest_dated_subdir(index_url: str, pattern: re.Pattern) -> str:
+    """Return the lexically newest dated subdirectory under index_url that matches pattern."""
+    page = requests.get(index_url, timeout=30)
+    page.raise_for_status()
+    soup = BeautifulSoup(page.content, "html.parser")
+    candidates = []
+    for link in soup.find_all("a"):
+        href = link.get("href", "")
+        m = pattern.match(href)
+        if m:
+            candidates.append((m.group("date"), href))
+    if not candidates:
+        raise RuntimeError(f"no dated subdirectories matched at {index_url}")
+    candidates.sort(key=lambda kv: datetime.strptime(kv[0][:8], "%Y%m%d"))
+    return candidates[-1][1]
+
+
+def ubuntu_rootfs(release: str, base_url: str) -> dict:
+    """Return { system: { url, sha256 } } for the latest release-* build under base_url."""
+    pattern = re.compile(r"^release-(?P<date>\d{8})/$")
+    latest = latest_dated_subdir(base_url, pattern)
+    build_url = f"{base_url}{latest}"
+    print(f"[+] {release}: {build_url}", file=sys.stderr)
+
+    page = requests.get(build_url, timeout=30)
+    page.raise_for_status()
+    soup = BeautifulSoup(page.content, "html.parser")
+
+    # Filenames look like ubuntu-22.04-server-cloudimg-amd64-root.tar.xz
+    rootfs_re = re.compile(
+        r"^.*-server-cloudimg-(?P<arch>amd64|arm64)-root\.tar\.xz$"
+    )
+    arch_to_system = {"amd64": "x86_64-linux", "arm64": "aarch64-linux"}
+
+    out = {}
+    for link in soup.find_all("a"):
+        href = link.get("href", "")
+        m = rootfs_re.match(href)
+        if not m:
+            continue
+        system = arch_to_system[m.group("arch")]
+        url = f"{build_url}{href}"
+        out[system] = {"url": url, "sha256": nix_hash(url)}
+    if not out:
+        raise RuntimeError(f"no rootfs tarballs found under {build_url}")
+    return out
+
+
+def debian_genericcloud(release: str, base_url: str) -> dict:
+    """Return { system: { url, sha256 } } for the latest dated debian build."""
+    pattern = re.compile(r"^(?P<date>\d{8}-\d{4})/$")
+    latest = latest_dated_subdir(base_url, pattern)
+    build_url = f"{base_url}{latest}"
+    print(f"[+] {release}: {build_url}", file=sys.stderr)
+
+    page = requests.get(build_url, timeout=30)
+    page.raise_for_status()
+    soup = BeautifulSoup(page.content, "html.parser")
+
+    # Filenames look like debian-13-genericcloud-amd64-20260413-2447.tar.xz
+    tarball_re = re.compile(
+        r"^.*-genericcloud-(?P<arch>amd64|arm64)-\d{8}-\d{4}\.tar\.xz$"
+    )
+    arch_to_system = {"amd64": "x86_64-linux", "arm64": "aarch64-linux"}
+
+    out: dict[str, dict] = {}
+    seen_urls: set[str] = set()
+    for link in soup.find_all("a"):
+        href = link.get("href", "")
+        m = tarball_re.match(href)
+        if not m:
+            continue
+        url = f"{build_url}{href}"
+        if url in seen_urls:
+            continue
+        seen_urls.add(url)
+        system = arch_to_system[m.group("arch")]
+        out[system] = {"url": url, "sha256": nix_hash(url)}
+    if not out:
+        raise RuntimeError(f"no genericcloud tarballs found under {build_url}")
+    return out
+
+
+def main() -> None:
+    images: dict[str, dict] = {}
+
+    for release, url in UBUNTU_RELEASES.items():
+        images[release] = ubuntu_rootfs(release, url)
+
+    for release, url in DEBIAN_RELEASES.items():
+        images[release] = debian_genericcloud(release, url)
+
+    IMAGES_JSON.write_text(json.dumps(images, indent=2, sort_keys=True) + "\n")
+    print(f"[+] wrote {IMAGES_JSON}", file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add container and VM tests for debian 13.
Unfortunately we have to restrict to x86_64-linux because libguestfs-appliance is not available on aarch64 in nixpkgs.

The good news is that we didn't have to change code to enable support.

Requires https://github.com/numtide/nix-vm-test/pull/168

This fixes #414 
