### PR TITLE
feat: add environment.variables, environment.sessionVariables, environment.extraSetup

### DIFF
--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -32,6 +32,47 @@
       default = "";
       description = "Shell script code which should be called before any shell session through the host /etc/profile.";
     };
+
+    variables = lib.mkOption {
+      default = { };
+      example = {
+        EDITOR = "nvim";
+        VISUAL = "nvim";
+      };
+      description = ''
+        A set of environment variables used in the global environment.
+        These variables will be set on shell initialisation (e.g. in /etc/profile).
+
+        The value of each variable can be either a string or a list of
+        strings.  The latter is concatenated, interspersed with colon
+        characters.
+
+        Setting a variable to `null` does nothing. You can override a
+        variable set by another module to `null` to unset it.
+      '';
+      type =
+        with lib.types;
+        attrsOf (
+          nullOr (oneOf [
+            (listOf (oneOf [
+              int
+              str
+              path
+            ]))
+            int
+            str
+            path
+          ])
+        );
+      apply =
+        let
+          toStr = v: if lib.isPath v then "${v}" else toString v;
+        in
+        attrs:
+        lib.mapAttrs (_: v: if lib.isList v then lib.concatMapStringsSep ":" toStr v else toStr v) (
+          lib.filterAttrs (_: v: v != null) attrs
+        );
+    };
   };
 
   config =
@@ -48,6 +89,7 @@
 
         etc = {
           "profile.d/system-manager-path.sh".source = pkgs.writeText "system-manager-path.sh" ''
+            ${lib.concatLines (lib.mapAttrsToList (k: v: ''export ${k}="${v}"'') config.environment.variables)}
             export PATH=${pathDir}/bin:''${PATH}
             ${config.environment.extraInit}
           '';

--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -1,6 +1,7 @@
 {
   lib,
   config,
+  options,
   pkgs,
   ...
 }:
@@ -73,6 +74,26 @@
           lib.filterAttrs (_: v: v != null) attrs
         );
     };
+
+    sessionVariables = lib.mkOption {
+      default = { };
+      description = ''
+        A set of environment variables used in the global environment.
+        These variables will be set by PAM early in the login process.
+
+        The value of each session variable can be either a string or a
+        list of strings. The latter is concatenated, interspersed with
+        colon characters.
+
+        Setting a variable to `null` does nothing. You can override a
+        variable set by another module to `null` to unset it.
+
+        Note: unlike NixOS, system-manager does not manage PAM on the
+        host, so these variables are not injected by pam_env into
+        non-shell sessions (e.g. graphical logins).
+      '';
+      inherit (options.environment.variables) type apply;
+    };
   };
 
   config =
@@ -86,6 +107,8 @@
         pathsToLink = [
           "/bin"
         ];
+
+        variables = config.environment.sessionVariables;
 
         etc = {
           "profile.d/system-manager-path.sh".source = pkgs.writeText "system-manager-path.sh" ''

--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -34,6 +34,12 @@
       description = "Shell script code which should be called before any shell session through the host /etc/profile.";
     };
 
+    extraSetup = lib.mkOption {
+      type = lib.types.lines;
+      default = "";
+      description = "Shell fragments to be run after the system environment has been created. This should only be used for things that need to modify the internals of the environment, e.g. generating MIME caches. The environment being built can be accessed at $out.";
+    };
+
     variables = lib.mkOption {
       default = { };
       example = {
@@ -144,6 +150,7 @@
               name = "system-manager-path";
               paths = config.environment.systemPackages;
               inherit (config.environment) pathsToLink;
+              postBuild = config.environment.extraSetup;
             };
           in
           ''

--- a/nix/modules/upstream/nixpkgs/programs/ssh.nix
+++ b/nix/modules/upstream/nixpkgs/programs/ssh.nix
@@ -36,12 +36,6 @@ in
       internal = true;
     };
 
-    environment.variables = lib.mkOption {
-      type = lib.types.attrsOf lib.types.str;
-      default = { };
-      internal = true;
-    };
-
     systemd.user.services = lib.mkOption {
       type = lib.types.attrs;
       default = { };

--- a/testFlake/container-tests/environment-variables.nix
+++ b/testFlake/container-tests/environment-variables.nix
@@ -1,0 +1,45 @@
+{ forEachDistro, ... }:
+
+forEachDistro "environment-variables" {
+  modules = [
+    (
+      { ... }:
+      {
+        environment.variables = {
+          FOO = "bar";
+          PATHLIKE = [
+            "/a"
+            "/b"
+            "/c"
+          ];
+          NULLED = null;
+        };
+      }
+    )
+  ];
+  testScriptFunction =
+    { toplevel, hostPkgs, ... }:
+    ''
+      start_all()
+
+      machine.wait_for_unit("multi-user.target")
+
+      activation_logs = machine.activate()
+      for line in activation_logs.split("\n"):
+          assert not "ERROR" in line, line
+      machine.wait_for_unit("system-manager.target")
+
+      with subtest("string variable is exported in login shell"):
+          value = machine.succeed("bash --login -c 'echo $FOO'").strip()
+          assert value == "bar", f"Expected 'bar', got: '{value}'"
+
+      with subtest("list variable is colon-joined in login shell"):
+          value = machine.succeed("bash --login -c 'echo $PATHLIKE'").strip()
+          assert value == "/a:/b:/c", f"Expected '/a:/b:/c', got: '{value}'"
+
+      with subtest("null-valued variable is dropped from profile script"):
+          content = machine.succeed("cat /etc/profile.d/system-manager-path.sh")
+          assert "FOO" in content, f"Expected FOO in profile script, got: {content}"
+          assert "NULLED" not in content, f"Expected NULLED to be absent, got: {content}"
+    '';
+}

--- a/testFlake/container-tests/environment-variables.nix
+++ b/testFlake/container-tests/environment-variables.nix
@@ -3,7 +3,7 @@
 forEachDistro "environment-variables" {
   modules = [
     (
-      { ... }:
+      { pkgs, ... }:
       {
         environment.variables = {
           FOO = "bar";
@@ -18,6 +18,11 @@ forEachDistro "environment-variables" {
         environment.sessionVariables = {
           SESSION_VAR = "from-session";
         };
+
+        environment.systemPackages = [ pkgs.hello ];
+        environment.extraSetup = ''
+          rm -f $out/bin/hello
+        '';
       }
     )
   ];
@@ -49,5 +54,8 @@ forEachDistro "environment-variables" {
       with subtest("sessionVariables are login shell exports"):
           value = machine.succeed("bash --login -c 'echo $SESSION_VAR'").strip()
           assert value == "from-session", f"Expected 'from-session', got: '{value}'"
+
+      with subtest("extraSetup removes binary from system PATH"):
+          machine.fail("test -e /run/system-manager/sw/bin/hello")
     '';
 }

--- a/testFlake/container-tests/environment-variables.nix
+++ b/testFlake/container-tests/environment-variables.nix
@@ -14,6 +14,10 @@ forEachDistro "environment-variables" {
           ];
           NULLED = null;
         };
+
+        environment.sessionVariables = {
+          SESSION_VAR = "from-session";
+        };
       }
     )
   ];
@@ -41,5 +45,9 @@ forEachDistro "environment-variables" {
           content = machine.succeed("cat /etc/profile.d/system-manager-path.sh")
           assert "FOO" in content, f"Expected FOO in profile script, got: {content}"
           assert "NULLED" not in content, f"Expected NULLED to be absent, got: {content}"
+
+      with subtest("sessionVariables are login shell exports"):
+          value = machine.succeed("bash --login -c 'echo $SESSION_VAR'").strip()
+          assert value == "from-session", f"Expected 'from-session', got: '{value}'"
     '';
 }


### PR DESCRIPTION
Add the missing NixOS shell-environment options that were missing.

Exports land in `/etc/profile.d/system-manager-path.sh`, which the host `/etc/profile` sources for login shells.
`extraSetup` is wired as `postBuild` on the `buildEnv` that produces `/run/system-manager/sw`, which is the same as nixos does.

We still don't cover zsh and non shell PAM sessions.

Closes #225.
