### PR TITLE
fix: add meta attributes for system-manager package

### DIFF
--- a/package.nix
+++ b/package.nix
@@ -47,4 +47,16 @@ rustPlatform.buildRustPackage {
     # https://nix.dev/manual/nix/2.24/command-ref/new-cli/nix3-profile#profiles
     export NIX_STATE_DIR=$TMPDIR
   '';
+
+  meta = {
+    description = "Manage system configurations using Nix on any Linux distribution";
+    homepage = "https://github.com/numtide/system-manager";
+    license = lib.licenses.mit;
+    platforms = [
+      "aarch64-linux"
+      "aarch64-darwin"
+      "x86_64-linux"
+    ];
+    mainProgram = "system-manager";
+  };
 }


### PR DESCRIPTION
Add complete meta information including mainProgram, description, homepage, license, and platforms to properly support lib.getExe and provide package metadata.