### PR TITLE
fix(systemd): warn that unit aliases are not supported

### DIFF
--- a/nix/modules/systemd.nix
+++ b/nix/modules/systemd.nix
@@ -223,8 +223,23 @@ in
     environment.etc =
       let
         enabledUnits = lib.filterAttrs (_: unit: unit.enable) cfg.units;
+        # The `aliases` option is part of the nixpkgs systemd unit schema and
+        # but system-manager does not implement it: we cannot emit
+        # sibling-relative alias symlinks safely because the activator
+        # canonicalises every symlink in the static env to an absolute store
+        # path, which turns the alias into a distinct unit sharing the
+        # primary's unit file (a foot-gun that can double-start services).
+        unitsWithAliases = lib.filterAttrs (_: unit: (unit.aliases or [ ]) != [ ]) enabledUnits;
+        aliasWarning =
+          "system-manager: the following units declare `aliases`, but"
+          + " system-manager does not support systemd unit aliases: the"
+          + " option is accepted yet nothing is emitted for it."
+          + " Use a second unit definition if you need the alias name"
+          + " to exist. See https://github.com/numtide/system-manager/issues/423."
+          + " Affected units: "
+          + lib.concatStringsSep ", " (lib.attrNames unitsWithAliases);
       in
-      {
+      lib.warnIf (unitsWithAliases != { }) aliasWarning {
         "systemd/system".source =
           pkgs.runCommand "system-manager-units"
             {

--- a/nix/modules/upstream/nixpkgs/userborn.nix
+++ b/nix/modules/upstream/nixpkgs/userborn.nix
@@ -39,6 +39,8 @@ in
 
   # REMOVE when https://github.com/NixOS/nixpkgs/pull/483684 is merged
   systemd.services.userborn = lib.mkIf config.services.userborn.enable {
+    # system-manager does not implement systemd aliases
+    aliases = lib.mkForce [ ];
     environment = {
       USERBORN_MUTABLE_USERS = "true";
       USERBORN_PREVIOUS_CONFIG = previousConfigPath;


### PR DESCRIPTION
The `aliases` option in systemd unit is accepted by the nixpkgs module system
but is silently dropped by system-manager.

Implementing it naively (emit a symlink next to the primary unit) is a
foot-gun under system-manager's activation model: the activator
canonicalises every symlink in the static env to an absolute store path,
so the alias lands as a distinct unit that shares the primary's unit
file. Anything that pulls the alias by name (distro-enabled dependency,
explicit `systemctl start <alias>`) then runs the primary's `ExecStart`
a second time, independently of the primary unit instance.

Until we fix that issue, emit a loud eval-time warning whenever any
enabled unit declares `aliases`, so downstream consumers stop relying on
a non-feature.

Also drop userborn's upstream `aliases = ["systemd-sysusers.service"]`
declaration, which is infrastructure the user cannot silence, so the
default install stays quiet.
