### PR TITLE
fix(users): support users.users.<name>.packages

### DIFF
--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -28,6 +28,15 @@
       default = [ ];
     };
 
+    extraOutputsToInstall = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        List of additional package outputs to be symlinked into
+        `/run/system-manager/sw` and per-user profiles.
+      '';
+    };
+
     extraInit = lib.mkOption {
       type = lib.types.lines;
       default = "";
@@ -102,6 +111,17 @@
     };
   };
 
+  options.system.path = lib.mkOption {
+    type = lib.types.package;
+    internal = true;
+    description = ''
+      The top-level system environment derivation, combining
+      `environment.systemPackages` into a single buildEnv. Exposed so
+      that modules copied verbatim from NixOS (e.g. `users-groups.nix`)
+      can reference `config.system.path.{ignoreCollisions,postBuild}`.
+    '';
+  };
+
   config =
     let
       pathDir = "/run/system-manager/sw";
@@ -120,6 +140,9 @@
           "profile.d/system-manager-path.sh".source = pkgs.writeText "system-manager-path.sh" ''
             ${lib.concatLines (lib.mapAttrsToList (k: v: ''export ${k}="${v}"'') config.environment.variables)}
             export PATH=${pathDir}/bin:''${PATH}
+            if [ -d "/etc/profiles/per-user/$USER/bin" ]; then
+              export PATH="/etc/profiles/per-user/$USER/bin:$PATH"
+            fi
             ${config.environment.extraInit}
           '';
 
@@ -136,6 +159,14 @@
         };
       };
 
+      system.path = pkgs.buildEnv {
+        name = "system-manager-path";
+        paths = config.environment.systemPackages;
+        inherit (config.environment) pathsToLink extraOutputsToInstall;
+        ignoreCollisions = true;
+        postBuild = config.environment.extraSetup;
+      };
+
       systemd.services.system-manager-path = {
         enable = true;
         description = "";
@@ -144,22 +175,13 @@
           Type = "oneshot";
           RemainAfterExit = true;
         };
-        script =
-          let
-            pathDrv = pkgs.buildEnv {
-              name = "system-manager-path";
-              paths = config.environment.systemPackages;
-              inherit (config.environment) pathsToLink;
-              postBuild = config.environment.extraSetup;
-            };
-          in
-          ''
-            mkdir --parents $(dirname "${pathDir}")
-            if [ -L "${pathDir}" ]; then
-              unlink "${pathDir}"
-            fi
-            ln --symbolic --force "${pathDrv}" "${pathDir}"
-          '';
+        script = ''
+          mkdir --parents $(dirname "${pathDir}")
+          if [ -L "${pathDir}" ]; then
+            unlink "${pathDir}"
+          fi
+          ln --symbolic --force "${config.system.path}" "${pathDir}"
+        '';
       };
     };
 }

--- a/testFlake/container-tests/user-packages.nix
+++ b/testFlake/container-tests/user-packages.nix
@@ -1,0 +1,47 @@
+{ forEachDistro, ... }:
+
+forEachDistro "user-packages" {
+  modules = [
+    (
+      { pkgs, ... }:
+      {
+        users.users.alice = {
+          isNormalUser = true;
+          uid = 3001;
+          packages = [ pkgs.hello ];
+        };
+      }
+    )
+  ];
+  testScriptFunction =
+    { toplevel, hostPkgs, ... }:
+    ''
+      start_all()
+
+      machine.wait_for_unit("multi-user.target")
+
+      activation_logs = machine.activate()
+      for line in activation_logs.split("\n"):
+          assert not "ERROR" in line, line
+      machine.wait_for_unit("system-manager.target")
+
+      with subtest("per-user profile is installed"):
+          machine.succeed("test -d /etc/profiles/per-user/alice")
+
+      with subtest("user packages are available in the profile"):
+          resolved = machine.succeed("readlink -f /etc/profiles/per-user/alice/bin/hello").strip()
+          assert resolved == "${hostPkgs.hello}/bin/hello", (
+              f"Expected hello from ${hostPkgs.hello}, got: {resolved}"
+          )
+
+      with subtest("hello is on alice's login shell PATH"):
+          which_hello = machine.succeed(
+              "su --login alice -c 'command -v hello'"
+          ).strip()
+          assert which_hello == "/etc/profiles/per-user/alice/bin/hello", (
+              f"Expected hello resolved from per-user profile, got: {which_hello}"
+          )
+          greeting = machine.succeed("su --login alice -c 'hello'").strip()
+          assert "Hello, world!" in greeting, f"Expected hello greeting, got: {greeting}"
+    '';
+}


### PR DESCRIPTION
Add the required options to support `users.users.<name>.packages`. This allows users to specify packages in their user configuration that will be symlinked into their per-user profile in `/etc/profiles/per-user/${name}` and added to their PATH.

This fixes #398