### PR TITLE
fix(ci): non flake compatibility error due to revCount

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -11,6 +11,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
       - uses: NixOS/nix-installer-action@main
         with:
           extra-conf: |


### PR DESCRIPTION
Since Nix 2.35, the `revCount` throw on shallow git checkouts. flake-compat rely on that so we now need to do a full depth clone.