### PR TITLE
feat: support XDG_DATA_DIRS and environment.d

### DIFF
--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -132,6 +132,7 @@
 
         pathsToLink = [
           "/bin"
+          "/share"
         ];
 
         variables = config.environment.sessionVariables;
@@ -143,7 +144,19 @@
             if [ -d "/etc/profiles/per-user/$USER/bin" ]; then
               export PATH="/etc/profiles/per-user/$USER/bin:$PATH"
             fi
+            if [ -d "/etc/profiles/per-user/$USER/share" ]; then
+              export XDG_DATA_DIRS="/etc/profiles/per-user/$USER/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+            fi
+            if [ -d "${pathDir}/share" ]; then
+              export XDG_DATA_DIRS="${pathDir}/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+            fi
             ${config.environment.extraInit}
+          '';
+
+          "environment.d/10-system-manager.conf".text = ''
+            ${lib.concatLines (lib.mapAttrsToList (k: v: ''${k}="${v}"'') config.environment.variables)}
+            PATH=/etc/profiles/per-user/''${USER}/bin:${pathDir}/bin:''${PATH}
+            XDG_DATA_DIRS=/etc/profiles/per-user/''${USER}/share:${pathDir}/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
           '';
 
           # TODO: figure out how to properly add fish support. We could start by

--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -144,11 +144,11 @@
             if [ -d "/etc/profiles/per-user/$USER/bin" ]; then
               export PATH="/etc/profiles/per-user/$USER/bin:$PATH"
             fi
-            if [ -d "/etc/profiles/per-user/$USER/share" ]; then
-              export XDG_DATA_DIRS="/etc/profiles/per-user/$USER/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
-            fi
             if [ -d "${pathDir}/share" ]; then
               export XDG_DATA_DIRS="${pathDir}/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
+            fi
+            if [ -d "/etc/profiles/per-user/$USER/share" ]; then
+              export XDG_DATA_DIRS="/etc/profiles/per-user/$USER/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
             fi
             ${config.environment.extraInit}
           '';

--- a/testFlake/container-tests/empty-config.nix
+++ b/testFlake/container-tests/empty-config.nix
@@ -16,6 +16,7 @@ forEachDistro "empty-config" {
           etc_entries = set(etc_json["entries"].keys())
           allowed_entries = {
               "profile.d/system-manager-path.sh",
+              "environment.d/10-system-manager.conf",
               "systemd/system",
               "tmpfiles.d",
           }
@@ -52,6 +53,7 @@ forEachDistro "empty-config" {
       # update this list only after confirming the change is intentional.
       allowed_changes = {
           "profile.d/system-manager-path.sh",
+          "environment.d/10-system-manager.conf",
           # systemd unit files
           "systemd/system/system-manager.target",
           "systemd/system/sysinit-reactivation.target",

--- a/testFlake/container-tests/environment-variables.nix
+++ b/testFlake/container-tests/environment-variables.nix
@@ -51,6 +51,12 @@ forEachDistro "environment-variables" {
           assert "FOO" in content, f"Expected FOO in profile script, got: {content}"
           assert "NULLED" not in content, f"Expected NULLED to be absent, got: {content}"
 
+      with subtest("variables are written to environment.d"):
+          content = machine.succeed("cat /etc/environment.d/10-system-manager.conf")
+          assert 'FOO="bar"' in content, f"Expected FOO in environment.d, got: {content}"
+          assert 'PATHLIKE="/a:/b:/c"' in content, f"Expected PATHLIKE in environment.d, got: {content}"
+          assert "NULLED" not in content, f"Expected NULLED to be absent, got: {content}"
+
       with subtest("sessionVariables are login shell exports"):
           value = machine.succeed("bash --login -c 'echo $SESSION_VAR'").strip()
           assert value == "from-session", f"Expected 'from-session', got: '{value}'"


### PR DESCRIPTION
## Description

This PR resolves issues where desktop applications (`.desktop` files) and environment variables defined via `system-manager` (including user profiles managed via Home Manager with `useUserPackages = true`) are not detected or loaded in graphical desktop environments.

### Key Changes
1. **Link `/share` by Default**: Added `"/share"` to `pathsToLink` in `nix/modules/environment.nix` so that shared assets (completions, fonts, icons, and desktop entries) are symlinked under `/run/system-manager/sw/share`.
2. **Support `XDG_DATA_DIRS`**: Updated `/etc/profile.d/system-manager-path.sh` to dynamically append the system (`/run/system-manager/sw/share`) and user (`/etc/profiles/per-user/$USER/share`) share paths to `XDG_DATA_DIRS`.
3. **Add `environment.d` Configuration**: Created `/etc/environment.d/10-system-manager.conf` to set up `PATH`, `XDG_DATA_DIRS`, and custom session variables for the systemd user manager (`systemd --user`). This ensures modern graphical sessions (GNOME, KDE, Wayland) inherit the correct environment variables and discover Nix applications automatically.
4. **Test Adjustments**: Updated container test allowed paths in `testFlake/container-tests/empty-config.nix` to allow `environment.d/` outputs.

