### PR TITLE
lib.nix: pick userborn using correct system attr

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -81,7 +81,13 @@ let
               system-manager = pkgs.callPackage ./packages/wrapper.nix {
                 system-manager-unwrapped = pkgs.callPackage ../package.nix { };
               };
-              userborn = userborn.packages.${config.nixpkgs.hostPlatform}.default;
+              userborn =
+                userborn.packages.${
+                  if config.nixpkgs.hostPlatform ? system then
+                    config.nixpkgs.hostPlatform.system
+                  else
+                    config.nixpkgs.hostPlatform
+                }.default;
             };
           };
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -106,7 +106,13 @@ let
               system-manager = pkgs.callPackage ./packages/wrapper.nix {
                 system-manager-unwrapped = pkgs.callPackage ../package.nix { };
               };
-              userborn = userborn.packages.${config.nixpkgs.hostPlatform}.default;
+              userborn =
+                userborn.packages.${
+                  if config.nixpkgs.hostPlatform ? system then
+                    config.nixpkgs.hostPlatform.system
+                  else
+                    config.nixpkgs.hostPlatform
+                }.default;
             };
           };
 

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -29,6 +29,9 @@ let
         Set `allowUnsupportedNixpkgs = true;` in `makeSystemConfig` to bypass this check.
       '';
 
+  # Returns the system string from a nixpkgs.
+  getSystem = cfg: if cfg.hostPlatform ? system then cfg.hostPlatform.system else cfg.hostPlatform;
+
   self = {
     # Function that can be used when defining inline modules to get better location
     # reporting in module-system errors.
@@ -73,7 +76,7 @@ let
                       }
                     else
                       {
-                        system = cfg.hostPlatform;
+                        system = getSystem cfg.hostPlatform;
                       };
                 in
                 import nixpkgs (
@@ -106,13 +109,7 @@ let
               system-manager = pkgs.callPackage ./packages/wrapper.nix {
                 system-manager-unwrapped = pkgs.callPackage ../package.nix { };
               };
-              userborn =
-                userborn.packages.${
-                  if config.nixpkgs.hostPlatform ? system then
-                    config.nixpkgs.hostPlatform.system
-                  else
-                    config.nixpkgs.hostPlatform
-                }.default;
+              userborn = userborn.packages.${getSystem config.nixpkgs}.default;
             };
           };
 

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -265,7 +265,9 @@
         '';
 
         deactivationScript = pkgs.writeShellScript "deactivate" ''
-          export PATH="$PATH:${lib.makeBinPath [ config.services.userborn.package ]}"
+          export PATH="$PATH:${
+            lib.makeBinPath (lib.optionals config.services.userborn.enable [ config.services.userborn.package ])
+          }"
           ${system-manager}/bin/system-manager-engine deactivate "$@"
         '';
 

--- a/nix/modules/default.nix
+++ b/nix/modules/default.nix
@@ -22,9 +22,10 @@
     {
       nixpkgs = {
         buildPlatform = lib.mkOption {
-          type = types.str;
+          type = with types; either str attrs;
           example = "x86_64-linux";
           default = config.nixpkgs.hostPlatform;
+          description = "The platform on which we are building the system configuration.";
         };
 
         hostPlatform = lib.mkOption {


### PR DESCRIPTION
If hostPlatform is an attrset, it just throws.

Still not sure this fixes cross compile but fixes eval, so drafting.