### PR TITLE
feat: track nixos-unstable on main, support stable on release branches

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -5,6 +5,8 @@ on:
   push:
     branches:
       - main
+      - "release-*"
+  workflow_dispatch:
 
 jobs:
   nix-build:

--- a/.github/workflows/nix-fmt.yml
+++ b/.github/workflows/nix-fmt.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - "release-*"
 
 jobs:
   nix-fmt:

--- a/.github/workflows/update-flake-lock.yml
+++ b/.github/workflows/update-flake-lock.yml
@@ -7,9 +7,17 @@ on:
 jobs:
   lockfile:
     runs-on: "ubuntu-latest"
+    strategy:
+      fail-fast: false
+      matrix:
+        branch:
+          - main
+          - release-26.05
     steps:
       - name: "Checkout the repo"
         uses: "actions/checkout@v6"
+        with:
+          ref: ${{ matrix.branch }}
       - name: "Install the Nix package manager"
         uses: "cachix/install-nix-action@master"
         with:
@@ -29,7 +37,8 @@ jobs:
       - name: "Create Pull Request"
         uses: "peter-evans/create-pull-request@v8"
         with:
-          branch: "auto_update_deps"
-          title: "Bump flake.lock, testFlake/flake.lock, and Cargo.lock"
+          base: ${{ matrix.branch }}
+          branch: "auto_update_deps-${{ matrix.branch }}"
+          title: "[${{ matrix.branch }}] Bump flake.lock, testFlake/flake.lock, and Cargo.lock"
           body: |
             Automatically bumped the lock files.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `main` now tracks `nixos-unstable` only, and stable Nixpkgs releases are supported on `release-XX.YY` branches, following the Home Manager model (#490)
+- Mismatched nixpkgs inputs now fail early with an explanatory error instead of an "option does not exist" trace (#490)
+
 - Breaking change: we disabled the nix module by default. To enable it, set `nix.enable = true` in your configuration. This allows users to choose their preferred Nix installation method and avoids conflicts with existing Nix setups. (#408)
 
 ## [1.1.0] - 2026-03-12

--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ cd ~/.config/system-manager
 
 Here is what `flake.nix` looks like. (Note: If you enabled experimental features from the command line rather than through `/etc/nix/nix.conf`, this file might not exist; you can create it manually and copy the following into it.)
 
+System Manager follows the same branching model as Home Manager: the `main` branch tracks `nixos-unstable`, and each `release-XX.YY` branch tracks the matching Nixpkgs stable release.
+Make sure both inputs refer to the same release, otherwise evaluation fails with an explanatory error.
+
 ```nix
 {
   description = "Standalone System Manager configuration";
@@ -231,6 +234,33 @@ System Manager is currently supported on NixOS, Ubuntu, and Debian. However, it 
 
 Nix should be installed with the [nix-installer](https://github.com/NixOS/nix-installer).
 System manager is tested against Nix 2.32 and above installed via nix-installer.
+
+## Nixpkgs compatibility
+
+System Manager imports a number of Nixpkgs NixOS modules, so a given version only works with the Nixpkgs release it was developed against.
+We follow the same branching model as Home Manager:
+
+| System Manager branch | Nixpkgs                       |
+| --------------------- | ----------------------------- |
+| `main`                | `nixos-unstable`              |
+| `release-26.05`       | `nixos-26.05`                 |
+
+We support the current stable release and unstable.
+When the inputs do not match, evaluation fails early with a message telling you which branch to use, rather than with an error deep inside module evaluation.
+
+To use System Manager with a stable Nixpkgs:
+
+```nix
+inputs = {
+  nixpkgs.url = "github:nixos/nixpkgs/nixos-26.05";
+  system-manager = {
+    url = "github:numtide/system-manager/release-26.05";
+    inputs.nixpkgs.follows = "nixpkgs";
+  };
+};
+```
+
+The check can be bypassed with `allowUnsupportedNixpkgs = true;` in `makeSystemConfig`, but combinations other than the ones above are untested and likely to fail.
 
 ## Sponsors
 

--- a/flake.lock
+++ b/flake.lock
@@ -61,11 +61,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {

--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -5,6 +5,30 @@
   userborn,
 }:
 let
+  # The nixpkgs releases this branch of system-manager is developed against.
+  supportedReleases = [ "26.11" ];
+
+  checkNixpkgsRelease =
+    allowUnsupportedNixpkgs: value:
+    if allowUnsupportedNixpkgs || lib.elem lib.trivial.release supportedReleases then
+      value
+    else
+      throw ''
+        This version of system-manager is meant to be used with nixpkgs ${lib.concatStringsSep " or " supportedReleases}, but you are using nixpkgs ${lib.trivial.release}.
+
+        system-manager follows the same branching model as home-manager:
+          - the main branch tracks nixos-unstable
+          - the release-XX.YY branches track the matching nixpkgs stable release
+
+        Either point system-manager at the release-${lib.trivial.release} branch:
+
+          inputs.system-manager.url = "github:numtide/system-manager/release-${lib.trivial.release}";
+
+        or make your nixpkgs input follow nixos-${lib.head supportedReleases}.
+
+        Set `allowUnsupportedNixpkgs = true;` in `makeSystemConfig` to bypass this check.
+      '';
+
   self = {
     # Function that can be used when defining inline modules to get better location
     # reporting in module-system errors.
@@ -24,6 +48,7 @@ let
         overlays ? [ ],
         extraSpecialArgs ? { },
         specialArgs ? { },
+        allowUnsupportedNixpkgs ? false,
       }:
       let
         # Module that sets additional module arguments
@@ -186,7 +211,7 @@ let
           in
           addPassthru (pkgs.linkFarm "system-manager" entries);
       in
-      returnIfNoAssertions toplevel;
+      checkNixpkgsRelease allowUnsupportedNixpkgs (returnIfNoAssertions toplevel);
 
     mkTestPreamble =
       {

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -57,6 +57,18 @@
         default = { };
       };
 
+      # Stub, we don't import the display manager modules.
+      services.displayManager.hiddenUsers = lib.mkOption {
+        type = lib.types.listOf lib.types.str;
+        default = [ ];
+      };
+
+      # Stub, we don't import the bash module.
+      programs.bash.completion.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+      };
+
       fonts.fontconfig.enable = lib.mkOption {
         type = lib.types.bool;
         default = false;

--- a/nix/modules/upstream/nixpkgs/nix.nix
+++ b/nix/modules/upstream/nixpkgs/nix.nix
@@ -1,39 +1,24 @@
 {
   lib,
-  pkgs,
   config,
   ...
 }:
 {
-  options = {
-    # options coming from modules/services/system/nix-daemon.nix that we cannot import just yet because it
-    # depends on users. These are the minimum options we need to be able to configure Nix using system-manager.
-    nix = {
-      enable = lib.mkOption {
-        type = lib.types.bool;
-        default = false;
-        description = ''
-          Whether to enable Nix.
-          Disabling Nix makes the system hard to modify and the Nix programs and configuration will not be made available by NixOS itself.
-        '';
-      };
-      package = lib.mkOption {
-        type = lib.types.package;
-        default = pkgs.nix;
-        defaultText = lib.literalExpression "pkgs.nix";
-        description = ''
-          This option specifies the Nix package instance to use throughout the system.
-        '';
-      };
-    };
-  };
+  config = lib.mkMerge [
+    {
+      nix.enable = lib.mkDefault false;
 
-  config = lib.mkIf config.nix.enable {
+      # Nix already owns its build users on the hosts we manage.
+      # Priority 900 overrides the upstream mkDefault, users can still set it.
+      nix.nrBuildUsers = lib.mkOverride 900 0;
+    }
 
-    environment.etc."nix/nix.conf".replaceExisting = true;
-    nix.settings.experimental-features = lib.mkDefault [
-      "nix-command"
-      "flakes"
-    ];
-  };
+    (lib.mkIf config.nix.enable {
+      environment.etc."nix/nix.conf".replaceExisting = true;
+      nix.settings.experimental-features = lib.mkDefault [
+        "nix-command"
+        "flakes"
+      ];
+    })
+  ];
 }

--- a/testFlake/flake.lock
+++ b/testFlake/flake.lock
@@ -129,11 +129,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1784489491,
-        "narHash": "sha256-j9maqjx1T8+ljAVntAdSI5hSGCm77QNZz64JF1rJNu0=",
+        "lastModified": 1786656209,
+        "narHash": "sha256-ybGtuwGKTUCefKYsplzvw4xcCqznto0c7BaiQhgILtA=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "3139deb8cafbe73b39b24451255b2fdd3426077e",
+        "rev": "c554d3441f725537854e877519f01cbd60680174",
         "type": "github"
       },
       "original": {
@@ -164,11 +164,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1784356753,
-        "narHash": "sha256-12KrbMiWLcf8m7pCvAtZh1ZrgF85ZXDXvfR/fWTKy84=",
+        "lastModified": 1786514691,
+        "narHash": "sha256-9dkt1i5JNbEfPb+EjLcSDNs8zqEHQ/1JlSaKgj0SBAg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "61b7c44c4073f0b827768aff0049561b5110ea5a",
+        "rev": "867dcbc30bafe3c862ef88620f2e7a109d7d3be5",
         "type": "github"
       },
       "original": {
@@ -270,11 +270,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1783174389,
-        "narHash": "sha256-aCWC8ngycU7OdJrU2+Je3qf+1a2ykuBvpPhZT/9tXMc=",
+        "lastModified": 1786629091,
+        "narHash": "sha256-gkig4nPi1CWc4Z50GBsjE4ygSE7hMpl/TwID2an2Cck=",
         "owner": "Mic92",
         "repo": "sops-nix",
-        "rev": "f1406619a3884cd5c47992a70b8b35c9c0fcb4c9",
+        "rev": "a8627b21b9107c5711c96b84f32a9a4b3d45295f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
nixpkgs NixOS/nixpkgs#536721 moved `nix.enable`, `nix.package` and the nixbld users. That broke evaluation against recent nixpkgs.

Rather than carry shims for both module layouts, we adopt the home-manager branching model: main tracks nixos-unstable, and each release-XX.YY branch tracks the matching nixpkgs stable release. The old layout is kept on the release-26.05 branch.

Mismatched inputs are now reported before module evaluation, since an incompatible nixpkgs otherwise fails deep inside evalModules, before any assertion can be rendered.

Fixes #521
Fixes #490