### PR TITLE
feat: save rootfs as tar to preserve group/other file permissions

### DIFF
--- a/crates/system-manager-engine/src/activate.rs
+++ b/crates/system-manager-engine/src/activate.rs
@@ -102,7 +102,7 @@ impl StateV1 {
                         backup_path.add_extension("v0back");
                         log::info!(
                             "Create a backup of the v0 state at {}.",
-                            &backup_path.display()
+                            backup_path.display()
                         );
                         fs::copy(state_file, backup_path)?;
                         Ok(filetree.into())

--- a/crates/system-manager-engine/src/activate/etc_files.rs
+++ b/crates/system-manager-engine/src/activate/etc_files.rs
@@ -332,13 +332,13 @@ fn create_etc_file(
             if old_state.contains(&target) {
                 log::debug!(
                     "{} is managed by system-manager. Deleting.",
-                    &target.display()
+                    target.display()
                 );
                 fs::remove_file(&target).map_err(|e| ActivationError::WithPartialResult {
                     result: state.clone(),
                     source: e.into(),
                 })?;
-                log::debug!("{} is managed by system-manager.", &target.display());
+                log::debug!("{} is managed by system-manager.", target.display());
                 unix::fs::symlink(file.source.store_path, &target).map_err(|e| {
                     ActivationError::WithPartialResult {
                         result: state.clone(),
@@ -422,7 +422,7 @@ fn find_uid(entry: &EtcFile) -> anyhow::Result<u32> {
                     || {
                         log::warn!(
                             "Specified user {} not found, defaulting to root",
-                            &entry.user
+                            entry.user
                         );
                         0
                     },
@@ -443,7 +443,7 @@ fn find_gid(entry: &EtcFile) -> anyhow::Result<u32> {
                     || {
                         log::warn!(
                             "Specified group {} not found, defaulting to root",
-                            &entry.group
+                            entry.group
                         );
                         0
                     },

--- a/lib/container-test-driver/make-rootfs.nix
+++ b/lib/container-test-driver/make-rootfs.nix
@@ -81,11 +81,13 @@ in
         pkgs.jq
       ];
     in
-    pkgs.runCommand "rootfs-${name}"
+    pkgs.runCommand "rootfs-${name}.tar"
       {
         inherit nativeBuildInputs;
       }
       ''
+        tarball=$out
+        out=$PWD/rootfs
         mkdir -p $out
 
         # Extract cloud image, excluding container-incompatible services
@@ -128,5 +130,7 @@ in
 
         # Run distro-specific setup
         ${extraSetup}
+
+        tar -C $out --sparse -cf $tarball .
       '';
 }

--- a/lib/container-test-driver/test_driver/driver.py
+++ b/lib/container-test-driver/test_driver/driver.py
@@ -67,17 +67,19 @@ class Driver:
 
         self.machines: list[Machine] = []
         for container in containers:
-            # Copy rootfs to container working directory
-            # Use --no-preserve=ownership so files become owned by root (current user)
+            # Extract tar of rootfs to container working directory
+            # Use --no-same-owner so files become owned by root (current user)
             # instead of preserving Nix store ownership which maps incorrectly in container
             container_rootdir = tempdir_path / container.name
+            container_rootdir.mkdir(parents=True, exist_ok=True)
             subprocess.run(
                 [
-                    "cp",
-                    "-r",
-                    "--no-preserve=ownership",
-                    str(container.rootfs),
+                    "tar",
+                    "--no-same-owner",
+                    "-C",
                     str(container_rootdir),
+                    "-xf",
+                    str(container.rootfs),
                 ],
                 check=True,
             )


### PR DESCRIPTION
If we can't preserve ownership at least preserve permissions so that it's easier to get to a working system when starting from a complex base image.