### PR TITLE
fix(environment): export NIX_PROFILES for per-user and system profiles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Export `NIX_PROFILES` (and `NIX_USER_PROFILE_DIR`) including `/run/system-manager/sw` and `/etc/profiles/per-user/$USER`, so zsh/bash completions from `environment.systemPackages`, `users.users.<name>.packages`, and Home Manager `useUserPackages` are visible to shells
+
 - `main` now tracks `nixos-unstable` only, and stable Nixpkgs releases are supported on `release-XX.YY` branches, following the Home Manager model (#490)
 - Mismatched nixpkgs inputs now fail early with an explanatory error instead of an "option does not exist" trace (#490)
 

--- a/nix/modules/environment.nix
+++ b/nix/modules/environment.nix
@@ -37,6 +37,18 @@
       '';
     };
 
+    profiles = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ ];
+      description = ''
+        A list of profiles used to setup the global environment.
+
+        Exported as the space-separated `NIX_PROFILES` variable (in reverse
+        order, matching NixOS) so that shells and completion systems can find
+        files under each profile, such as `share/zsh/site-functions`.
+      '';
+    };
+
     extraInit = lib.mkOption {
       type = lib.types.lines;
       default = "";
@@ -125,6 +137,7 @@
   config =
     let
       pathDir = "/run/system-manager/sw";
+      nixProfiles = lib.concatStringsSep " " (lib.reverseList config.environment.profiles);
     in
     {
       environment = {
@@ -133,6 +146,12 @@
         pathsToLink = [
           "/bin"
           "/share"
+        ];
+
+        # Last entries become first in NIX_PROFILES, matching NixOS.
+        profiles = lib.mkAfter [
+          "/nix/var/nix/profiles/default"
+          pathDir
         ];
 
         variables = config.environment.sessionVariables;
@@ -150,6 +169,8 @@
             if [ -d "/etc/profiles/per-user/$USER/share" ]; then
               export XDG_DATA_DIRS="/etc/profiles/per-user/$USER/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}"
             fi
+            export NIX_USER_PROFILE_DIR="/nix/var/nix/profiles/per-user/$USER"
+            export NIX_PROFILES="${nixProfiles}"
             ${config.environment.extraInit}
           '';
 
@@ -157,6 +178,8 @@
             ${lib.concatLines (lib.mapAttrsToList (k: v: ''${k}="${v}"'') config.environment.variables)}
             PATH=/etc/profiles/per-user/''${USER}/bin:${pathDir}/bin:''${PATH}
             XDG_DATA_DIRS=/etc/profiles/per-user/''${USER}/share:${pathDir}/share:''${XDG_DATA_DIRS:-/usr/local/share:/usr/share}
+            NIX_USER_PROFILE_DIR=/nix/var/nix/profiles/per-user/''${USER}
+            NIX_PROFILES="${nixProfiles}"
           '';
 
           # TODO: figure out how to properly add fish support. We could start by

--- a/nix/modules/upstream/nixpkgs/users-groups.nix
+++ b/nix/modules/upstream/nixpkgs/users-groups.nix
@@ -947,13 +947,13 @@ in
         }
       ) (filterAttrs (_: u: u.packages != [ ]) cfg.users);
 
-      # environment.profiles = [
-      #   "$HOME/.nix-profile"
-      #   "\${XDG_STATE_HOME}/nix/profile"
-      #   "$HOME/.local/state/nix/profile"
-      #   "/etc/profiles/per-user/$USER"
-      # ];
-      #
+      environment.profiles = [
+        "$HOME/.nix-profile"
+        "\${XDG_STATE_HOME}/nix/profile"
+        "$HOME/.local/state/nix/profile"
+        "/etc/profiles/per-user/$USER"
+      ];
+
       # systemd initrd
       # boot.initrd.systemd = lib.mkIf config.boot.initrd.systemd.enable {
       #   contents = {

--- a/testFlake/container-tests/environment-variables.nix
+++ b/testFlake/container-tests/environment-variables.nix
@@ -56,6 +56,22 @@ forEachDistro "environment-variables" {
           assert 'FOO="bar"' in content, f"Expected FOO in environment.d, got: {content}"
           assert 'PATHLIKE="/a:/b:/c"' in content, f"Expected PATHLIKE in environment.d, got: {content}"
           assert "NULLED" not in content, f"Expected NULLED to be absent, got: {content}"
+          assert "/run/system-manager/sw" in content, f"Expected system profile in NIX_PROFILES, got: {content}"
+          assert "/etc/profiles/per-user/" in content, (
+              f"Expected per-user profile in NIX_PROFILES, got: {content}"
+          )
+
+      with subtest("NIX_PROFILES is exported in login shell"):
+          content = machine.succeed("cat /etc/profile.d/system-manager-path.sh")
+          assert "NIX_PROFILES=" in content, f"Expected NIX_PROFILES in profile script, got: {content}"
+          assert "/run/system-manager/sw" in content, f"Expected system profile in NIX_PROFILES, got: {content}"
+          value = machine.succeed("bash --login -c 'echo $NIX_PROFILES'").strip()
+          assert "/run/system-manager/sw" in value.split(), (
+              f"Expected /run/system-manager/sw in NIX_PROFILES, got: {value!r}"
+          )
+          assert "/etc/profiles/per-user/" in value, (
+              f"Expected per-user profile in NIX_PROFILES, got: {value!r}"
+          )
 
       with subtest("sessionVariables are login shell exports"):
           value = machine.succeed("bash --login -c 'echo $SESSION_VAR'").strip()

--- a/testFlake/container-tests/home-manager.nix
+++ b/testFlake/container-tests/home-manager.nix
@@ -68,5 +68,13 @@ forEachDistro "home-manager" {
           assert "/etc/profiles/per-user/hmuser/bin/hello" == resolved, (
               f"Expected hello from per-user profile, got: {resolved!r}"
           )
+
+      with subtest("home-manager useUserPackages profile is in NIX_PROFILES"):
+          nix_profiles = machine.succeed(
+              "runuser -u hmuser -- bash -lc 'echo $NIX_PROFILES'"
+          ).strip()
+          assert "/etc/profiles/per-user/hmuser" in nix_profiles.split(), (
+              f"Expected per-user profile in NIX_PROFILES, got: {nix_profiles!r}"
+          )
     '';
 }

--- a/testFlake/container-tests/user-packages.nix
+++ b/testFlake/container-tests/user-packages.nix
@@ -43,5 +43,14 @@ forEachDistro "user-packages" {
           )
           greeting = machine.succeed("su --login alice -c 'hello'").strip()
           assert "Hello, world!" in greeting, f"Expected hello greeting, got: {greeting}"
+
+      with subtest("alice's NIX_PROFILES includes the per-user profile"):
+          nix_profiles = machine.succeed("su --login alice -c 'echo $NIX_PROFILES'").strip()
+          assert "/etc/profiles/per-user/alice" in nix_profiles.split(), (
+              f"Expected per-user profile in NIX_PROFILES, got: {nix_profiles!r}"
+          )
+          assert "/run/system-manager/sw" in nix_profiles.split(), (
+              f"Expected system profile in NIX_PROFILES, got: {nix_profiles!r}"
+          )
     '';
 }


### PR DESCRIPTION
## Description

Fixes #531.

NixOS exports `NIX_PROFILES` from `environment.profiles` so shells (and Home Manager's zsh module) can find `share/zsh/site-functions`. system-manager only set `PATH` and `XDG_DATA_DIRS`, so packages from `useUserPackages` / `users.users.<name>.packages` / `environment.systemPackages` ran, but tab completion did not.

This is the same gap left after #505, which linked `/share` and wired desktop discovery but not `NIX_PROFILES`.

### Key Changes

1. **Add `environment.profiles`**: Match NixOS. `users-groups.nix` again contributes the user profile list (`$HOME/.nix-profile`, XDG state profile, `/etc/profiles/per-user/$USER`); system-manager appends `/nix/var/nix/profiles/default` and `/run/system-manager/sw`.
2. **Export `NIX_PROFILES`**: Written to `/etc/profile.d/system-manager-path.sh` and `/etc/environment.d/10-system-manager.conf` in reverse profile order, plus `NIX_USER_PROFILE_DIR`.
3. **Tests**: Assert `NIX_PROFILES` in login shells for the environment-variables, user-packages, and home-manager container tests.
