### PR TITLE
feat: align Nix path and flake registry with NixOS

### DIFF
--- a/nix/lib.nix
+++ b/nix/lib.nix
@@ -123,6 +123,14 @@ let
               _file = "${self.printAttrPos (builtins.unsafeGetAttrPos "a" { a = null; })}: inline module";
               build = { inherit toplevel; };
             }
+            (
+              { lib, ... }:
+              {
+                config.nixpkgs.flake.source = lib.mkIf (
+                  builtins.isAttrs nixpkgs && nixpkgs ? outPath
+                ) nixpkgs.outPath;
+              }
+            )
             {
               config = {
                 assertions = [

--- a/nix/modules/upstream/nixpkgs/default.nix
+++ b/nix/modules/upstream/nixpkgs/default.nix
@@ -23,11 +23,13 @@
     map (path: nixosModulesPath + path) [
       "/misc/meta.nix"
       "/misc/ids.nix"
+      "/misc/nixpkgs-flake.nix"
       "/security/acme/"
       "/security/sudo.nix"
       "/security/wrappers/"
       "/services/web-servers/nginx/"
       # nix settings
+      "/config/nix-flakes.nix"
       "/config/nix.nix"
       "/services/system/userborn.nix"
       "/system/build.nix"
@@ -67,6 +69,12 @@
       programs.bash.completion.enable = lib.mkOption {
         type = lib.types.bool;
         default = false;
+      };
+
+      nix.channel.enable = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        internal = true;
       };
 
       fonts.fontconfig.enable = lib.mkOption {

--- a/nix/modules/upstream/nixpkgs/nix.nix
+++ b/nix/modules/upstream/nixpkgs/nix.nix
@@ -3,7 +3,19 @@
   config,
   ...
 }:
+let
+  cfg = config.nix;
+in
 {
+  options.nix.nixPath = lib.mkOption {
+    type = lib.types.listOf lib.types.str;
+    default = [ ];
+    description = ''
+      The default Nix expression search path, used by the Nix evaluator to
+      look up paths enclosed in angle brackets (e.g. `<nixpkgs>`).
+    '';
+  };
+
   config = lib.mkMerge [
     {
       nix.enable = lib.mkDefault false;
@@ -15,6 +27,10 @@
 
     (lib.mkIf config.nix.enable {
       environment.etc."nix/nix.conf".replaceExisting = true;
+      environment.etc."nix/registry.json".replaceExisting = true;
+      environment.sessionVariables = lib.mkIf (cfg.nixPath != [ ]) {
+        NIX_PATH = cfg.nixPath;
+      };
       nix.settings.experimental-features = lib.mkDefault [
         "nix-command"
         "flakes"

--- a/testFlake/container-tests/nix-enabled.nix
+++ b/testFlake/container-tests/nix-enabled.nix
@@ -10,8 +10,14 @@ forEachDistro "nix-enabled" {
     )
   ];
   testScriptFunction =
-    { toplevel, hostPkgs, ... }:
+    {
+      toplevel,
+      hostPkgs,
+      ...
+    }:
     ''
+      import json
+
       start_all()
 
       machine.wait_for_unit("multi-user.target")
@@ -19,6 +25,10 @@ forEachDistro "nix-enabled" {
       with subtest("Pre-existing nix.conf before activation"):
           assert machine.file("/etc/nix/nix.conf").exists, "/etc/nix/nix.conf should exist before activation"
           original_nix_conf = machine.succeed("cat /etc/nix/nix.conf")
+
+      with subtest("Pre-existing registry before activation"):
+          original_registry = '{"flakes":[],"version":2}'
+          machine.succeed(f"printf %s '{original_registry}' > /etc/nix/registry.json")
 
       machine.activate()
       machine.wait_for_unit("system-manager.target")
@@ -29,6 +39,23 @@ forEachDistro "nix-enabled" {
           assert nix_conf.contains("experimental-features"), "nix.conf should contain experimental-features"
           assert nix_conf.contains("nix-command"), "nix.conf should contain nix-command"
           assert nix_conf.contains("flakes"), "nix.conf should contain flakes"
+
+      with subtest("nix-path is exported in login shells"):
+          nix_path = machine.succeed("bash --login -c 'printf %s \"$NIX_PATH\"'").strip()
+          assert nix_path == "nixpkgs=flake:nixpkgs", (
+              f"Expected configured NIX_PATH, got: {nix_path!r}"
+          )
+
+      with subtest("nixpkgs is registered system-wide"):
+          registry = json.loads(machine.succeed("cat /etc/nix/registry.json"))
+          assert registry == {
+              "version": 2,
+              "flakes": [{
+                  "exact": True,
+                  "from": {"id": "nixpkgs", "type": "indirect"},
+                  "to": {"path": "${toplevel.config.nixpkgs.flake.source}", "type": "path"},
+              }],
+          }, f"Unexpected flake registry: {registry!r}"
 
       with subtest("Re-activation succeeds"):
           machine.activate()
@@ -41,5 +68,10 @@ forEachDistro "nix-enabled" {
           machine.succeed("${toplevel}/bin/deactivate")
           restored_nix_conf = machine.succeed("cat /etc/nix/nix.conf")
           assert restored_nix_conf == original_nix_conf, f"nix.conf content differs after deactivation:\n  original: {original_nix_conf!r}\n  restored: {restored_nix_conf!r}"
+          restored_registry = machine.succeed("cat /etc/nix/registry.json")
+          assert restored_registry == original_registry, (
+              f"registry.json content differs after deactivation:\n"
+              f"  original: {original_registry!r}\n  restored: {restored_registry!r}"
+          )
     '';
 }


### PR DESCRIPTION
Closes #546.

Reuse the upstream NixOS flake registry modules and inject the nixpkgs flake source in `makeSystemConfig`. This pins the system-wide `nixpkgs` registry entry and exports `nixpkgs=flake:nixpkgs` through `NIX_PATH` while preserving an existing registry across activation and deactivation.

## Tests

- `nix flake check --no-build`
- `nix build ./testFlake#checks.x86_64-linux.container-ubuntu-22_04-nix-enabled ./testFlake#checks.x86_64-linux.container-ubuntu-24_04-nix-enabled ./testFlake#checks.x86_64-linux.container-debian-13-nix-enabled -L`